### PR TITLE
Adjust todo.Subject output

### DIFF
--- a/todolist/app.go
+++ b/todolist/app.go
@@ -146,7 +146,7 @@ func (a *App) ExpandTodo(input string) {
 	commonProject := parser.ExpandProject(input)
 	todos := strings.LastIndex(input, ":")
 	if commonProject == "" || len(input) <= todos+1 || todos == -1 {
-		fmt.Println("I'm expecting a format like \"todolist ex <project>: <todo1>, <todo2>, ...\"")
+		fmt.Println("I'm expecting a format like \"todolist ex <todoID> <project>: <todo1>, <todo2>, ...\"")
 		return
 	}
 

--- a/todolist/screen_printer.go
+++ b/todolist/screen_printer.go
@@ -53,11 +53,13 @@ func (f *ScreenPrinter) printTodo(todo *Todo) {
 	if todo.IsPriority {
 		yellow.Add(color.Bold, color.Italic)
 	}
+
+	re, _ := regexp.Compile(`[[:space:]]+`)
 	fmt.Fprintf(f.Writer, " %s\t%s\t%s\t%s\t\n",
 		yellow.SprintFunc()(strconv.Itoa(todo.Id)),
 		f.formatCompleted(todo.Completed),
 		f.formatDue(todo.Due, todo.IsPriority),
-		f.formatSubject(todo.Subject, todo.IsPriority))
+		f.formatSubject(re.ReplaceAllString(todo.Subject, " "), todo.IsPriority))
 }
 
 func (f *ScreenPrinter) formatDue(due string, isPriority bool) string {


### PR DESCRIPTION
This patch fix #116 by working on the output stage.

Commands like `expand` that generates todo.Subject in raw format string
may contain continuous spaces. This out-of-the-box fix save users' time
from fixing the strings in their old todo.json, and prevents the same
problem that will be introduced by any future function extensions.

Impact: Now we do NOT allow continuous spaces characters in the subject
string, including projects and contexts.