### PR TITLE
Fixed the bug that tasks with no due date also get displayed whenever only want to display overdue tasks

### DIFF
--- a/todolist/date_filter.go
+++ b/todolist/date_filter.go
@@ -182,6 +182,9 @@ func (f *DateFilter) filterOverdue(pivot time.Time) []*Todo {
 	pivotDate := pivot.Format("2006-01-02")
 
 	for _, todo := range f.Todos {
+		if todo.Due == "" || todo.Completed {
+			continue
+		}
 		dueTime, _ := time.ParseInLocation("2006-01-02", todo.Due, f.Location)
 		if dueTime.Before(pivot) && pivotDate != todo.Due {
 			ret = append(ret, todo)


### PR DESCRIPTION
Fixed the bug that tasks with no due date also get displayed whenever only want to display overdue tasks

[*] This fix is tested and verified locally on my machine on Jan. 31, 2017 1:40AM.