### PR TITLE
Support case insensitive dates

### DIFF
--- a/todolist/date_filter.go
+++ b/todolist/date_filter.go
@@ -3,6 +3,7 @@ package todolist
 import (
 	"regexp"
 	"time"
+        "strings"
 )
 
 type DateFilter struct {
@@ -30,7 +31,7 @@ func (f *DateFilter) FilterDate(input string) []*Todo {
 
 	// filter due items
 	r, _ := regexp.Compile(`due .*$`)
-	match := r.FindString(input)
+	match := strings.ToLower(r.FindString(input))
 	switch {
 	case match == "due tod" || match == "due today":
 		return f.filterDueToday(bod(time.Now()))
@@ -62,7 +63,7 @@ func (f *DateFilter) FilterDate(input string) []*Todo {
 
 	// filter completed items
 	r, _ = regexp.Compile(`completed .*$`)
-	match = r.FindString(input)
+	match = strings.ToLower(r.FindString(input))
 	switch {
 	case match == "completed tod" || match == "completed today":
 		return f.filterCompletedToday(bod(time.Now()))


### PR DESCRIPTION
👋 First thing I did after pulling this down was to try and add a todo item:

```
todo a Define list of high priority issues for @projectX due Friday
```

I got back:

```
Could not parse the date you gave me: Friday
I'm expecting a date like "Dec 22" or "22 Dec".
See http://todolist.site/#adding for more info.
```

I took a peak at the code and saw that the strings were being compared to lowercase day names without being downcased first. Since I almost always type names of days with an uppercase letter, thought I'd (selfishly) fix that.

Note: I don't write/build Go, so this is untested. Thought it was simple enough to give it a shot.
