### PR TITLE
Ensure id has enough width

### DIFF
--- a/todolist/screen_printer.go
+++ b/todolist/screen_printer.go
@@ -54,7 +54,7 @@ func (f *ScreenPrinter) printTodo(todo *Todo) {
 		yellow.Add(color.Bold, color.Italic)
 	}
 	fmt.Fprintf(f.Writer, " %s\t%s\t%s\t%s\t\n",
-		yellow.SprintFunc()(strconv.Itoa(todo.Id)),
+		yellow.SprintFunc()(fmt.Sprintf("%-4d", todo.Id)),
 		f.formatCompleted(todo.Completed),
 		f.formatDue(todo.Due, todo.IsPriority),
 		f.formatSubject(todo.Subject, todo.IsPriority))


### PR DESCRIPTION
the ID column looked wonky after I groomed my list and had ids ranging from 1 digit to 3 digits.  This fixes the problem.

Before:
![image](https://user-images.githubusercontent.com/38560/44211981-240ef280-a138-11e8-9a67-15a057ce92f1.png)

After:
![image](https://user-images.githubusercontent.com/38560/44212006-36892c00-a138-11e8-948d-2ad5e41c3d43.png)

Interestingly, this problem only presents itself for me when I'm not using tmux.  when I use todolist within tmux, the id formatting is fine.  :man_shrugging: 