### PR TITLE
Fix app name in initialization instructions

### DIFF
--- a/ultralist/file_store.go
+++ b/ultralist/file_store.go
@@ -41,7 +41,7 @@ func (f *FileStore) Load() ([]*Todo, error) {
 	data, err := ioutil.ReadFile(f.FileLocation)
 	if err != nil {
 		fmt.Println("No todo file found!")
-		fmt.Println("Initialize a new todo repo by running 'todolist init'")
+		fmt.Println("Initialize a new todo repo by running 'ultralist init'")
 		os.Exit(0)
 		return nil, err
 	}


### PR DESCRIPTION
Wanted to try out Ultralist and found that the instruction string printed when running `ultralist ln` without a todo repo used the app’s old name.