### PR TITLE
Fixing screen printer output for a todo with no due date but priority.

### DIFF
--- a/ultralist/screen_printer.go
+++ b/ultralist/screen_printer.go
@@ -70,7 +70,7 @@ func (f *ScreenPrinter) formatDue(due string, isPriority bool, completed bool) s
 	}
 
 	if due == "" {
-		return blue.SprintFunc()("          ")
+		return color.New().SprintFunc()("          ")
 	}
 	dueTime, err := time.Parse("2006-01-02", due)
 


### PR DESCRIPTION
If a todo is priority but has no due date the background color in `formatDue` is set to blue which looks odd in some terminals.

Before:
<img width="876" alt="screenshot 2019-03-08 at 00 06 10" src="https://user-images.githubusercontent.com/1560363/53995820-9bd55680-4136-11e9-91d6-4a686072a429.png">

After:
<img width="876" alt="screenshot 2019-03-08 at 00 06 23" src="https://user-images.githubusercontent.com/1560363/53995828-a55ebe80-4136-11e9-9d0c-c0b7e4f969d2.png">
