### PR TITLE
Reworking MaxID and NextID in order to have the real MaxID and NextID.

### DIFF
--- a/ultralist/app.go
+++ b/ultralist/app.go
@@ -267,7 +267,7 @@ func (a *App) HandleNotes(input string) {
 	} else if parser.ParseShowNote(todo, input) {
 		groups := map[string][]*Todo{}
 		groups[""] = append(groups[""], todo)
-		a.Printer.Print(&GroupedTodos{Groups: groups}, true)
+		a.Printer.Print(&GroupedTodos{Groups: groups}, a.TodoList.MaxID(), true)
 		return
 	}
 	a.save()
@@ -292,7 +292,7 @@ func (a *App) ListTodos(input string) {
 	grouped := a.getGroups(input, filtered)
 
 	re, _ := regexp.Compile(`^ln`)
-	a.Printer.Print(grouped, re.MatchString(input))
+	a.Printer.Print(grouped, a.TodoList.MaxID(), re.MatchString(input))
 }
 
 // PrioritizeTodo will prioritize a todo.
@@ -392,6 +392,12 @@ func (a *App) OpenWeb() {
 
 	fmt.Println("Opening this list on your browser...")
 	open.Start("https://app.ultralist.io/todolist/" + a.EventLogger.CurrentSyncedList.UUID)
+}
+
+// MaxID returns the maximum human readable ID of all todo items.
+func (a *App) MaxID() int {
+	a.Load()
+	return a.TodoList.MaxID()
 }
 
 // Save the todolist to the store.

--- a/ultralist/memory_printer.go
+++ b/ultralist/memory_printer.go
@@ -6,6 +6,6 @@ type MemoryPrinter struct {
 }
 
 // Print is printing grouped todos.
-func (m *MemoryPrinter) Print(groupedTodos *GroupedTodos, printNotes bool) {
+func (m *MemoryPrinter) Print(groupedTodos *GroupedTodos, maxTodoID int, printNotes bool) {
 	m.Groups = groupedTodos
 }

--- a/ultralist/printer.go
+++ b/ultralist/printer.go
@@ -2,5 +2,5 @@ package ultralist
 
 // Printer is an interface for printing grouped todos.
 type Printer interface {
-	Print(*GroupedTodos, bool)
+	Print(*GroupedTodos, int, bool)
 }

--- a/ultralist/screen_printer.go
+++ b/ultralist/screen_printer.go
@@ -41,7 +41,7 @@ func NewScreenPrinter() *ScreenPrinter {
 }
 
 // Print prints the output of ultralist to the terminal screen.
-func (f *ScreenPrinter) Print(groupedTodos *GroupedTodos, printNotes bool) {
+func (f *ScreenPrinter) Print(groupedTodos *GroupedTodos, maxTodoID int, printNotes bool) {
 	var keys []string
 	for key := range groupedTodos.Groups {
 		keys = append(keys, key)
@@ -53,31 +53,38 @@ func (f *ScreenPrinter) Print(groupedTodos *GroupedTodos, printNotes bool) {
 	for _, key := range keys {
 		tabby.AddLine(cyan.Sprint(key))
 		for _, todo := range groupedTodos.Groups[key] {
-			f.printTodo(tabby, todo, printNotes)
+			f.printTodo(tabby, todo, maxTodoID, printNotes)
 		}
 		tabby.AddLine()
 	}
 	tabby.Print()
 }
 
-func (f *ScreenPrinter) printTodo(tabby *tabby.Tabby, todo *Todo, printNotes bool) {
+func (f *ScreenPrinter) printTodo(tabby *tabby.Tabby, todo *Todo, maxTodoID int, printNotes bool) {
 	tabby.AddLine(
-		f.formatID(todo.ID, todo.IsPriority),
+		f.formatID(todo.ID, maxTodoID, todo.IsPriority),
 		f.formatCompleted(todo.Completed),
 		f.formatDue(todo.Due, todo.IsPriority, todo.Completed),
 		f.formatSubject(todo.Subject, todo.IsPriority))
 	if printNotes {
 		for nid, note := range todo.Notes {
-			tabby.AddLine("  "+cyan.Sprint(strconv.Itoa(nid)), white.Sprint(""), white.Sprint(""), white.Sprint(""), white.Sprint(note))
+			tabby.AddLine(f.formatIDOffset(nid, maxTodoID)+cyan.Sprint(strconv.Itoa(nid)), white.Sprint(""), white.Sprint(""), white.Sprint(""), white.Sprint(note))
 		}
 	}
 }
 
-func (f *ScreenPrinter) formatID(ID int, isPriority bool) string {
+func (f *ScreenPrinter) formatID(ID int, maxTodoID int, isPriority bool) string {
 	if isPriority {
-		return yellowBold.Sprint(strconv.Itoa(ID))
+		return f.formatIDOffset(ID, maxTodoID) + yellowBold.Sprint(strconv.Itoa(ID))
 	}
-	return yellow.Sprint(strconv.Itoa(ID))
+	return f.formatIDOffset(ID, maxTodoID) + yellow.Sprint(strconv.Itoa(ID))
+}
+
+func (f *ScreenPrinter) formatIDOffset(ID int, maxTodoID int) string {
+	offset := len(strconv.Itoa(maxTodoID)) - len(strconv.Itoa(ID))
+	spaces := " "
+	spaces += strings.Repeat(" ", offset)
+	return spaces
 }
 
 func (f *ScreenPrinter) formatCompleted(completed bool) string {

--- a/ultralist/todo_list.go
+++ b/ultralist/todo_list.go
@@ -1,6 +1,8 @@
 package ultralist
 
-import "sort"
+import (
+	"sort"
+)
 
 // TodoList is the struct of a list with several todos.
 type TodoList struct {
@@ -146,32 +148,21 @@ func (t *TodoList) Todos() []*Todo {
 
 // MaxID returns the maximum human readable ID of all todo items.
 func (t *TodoList) MaxID() int {
-	maxID := 0
+	var keys []int
 	for _, todo := range t.Data {
-		if todo.ID > maxID {
-			maxID = todo.ID
-		}
+		keys = append(keys, todo.ID)
 	}
-	return maxID
+	todos := len(keys)
+	if todos > 0 {
+		sort.Ints(keys)
+		return keys[len(keys)-1]
+	}
+	return 0
 }
 
 // NextID returns the next human readable ID.
 func (t *TodoList) NextID() int {
-	var found bool
-	maxID := t.MaxID()
-	for i := 1; i <= maxID; i++ {
-		found = false
-		for _, todo := range t.Data {
-			if todo.ID == i {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return i
-		}
-	}
-	return maxID + 1
+	return t.MaxID() + 1
 }
 
 // FindByID finds a todo by ID.

--- a/ultralist/todo_list_test.go
+++ b/ultralist/todo_list_test.go
@@ -17,30 +17,31 @@ func TestNextID(t *testing.T) {
 
 func TestNextIDWhenTodoDeleted(t *testing.T) {
 	assert := assert.New(t)
-	todo := &Todo{Subject: "testing", Completed: false, Archived: false}
-	todo2 := &Todo{Subject: "testing2", Completed: false, Archived: false}
-	todo3 := &Todo{Subject: "testing3", Completed: false, Archived: false}
+	todo1 := &Todo{Subject: "testing 1", Completed: false, Archived: false}
+	todo2 := &Todo{Subject: "testing 2", Completed: false, Archived: false}
+	todo3 := &Todo{Subject: "testing 3", Completed: false, Archived: false}
+	todo4 := &Todo{Subject: "testing 4", Completed: false, Archived: false}
 	list := &TodoList{}
 
-	list.Add(todo)
+	list.Add(todo1)
 	list.Add(todo2)
 	list.Add(todo3)
 
 	list.Delete(2)
-	assert.Equal(2, list.NextID())
-	list.Add(todo2)
 	assert.Equal(4, list.NextID())
+	list.Add(todo4)
+	assert.Equal(5, list.NextID())
 	list.Delete(1)
-	assert.Equal(1, list.NextID())
+	assert.Equal(5, list.NextID())
 }
 
 func TestMaxID(t *testing.T) {
 	assert := assert.New(t)
-	todo := &Todo{Subject: "testing", Completed: false, Archived: false}
+	todo1 := &Todo{Subject: "testing 1", Completed: false, Archived: false}
 	todo2 := &Todo{Subject: "testing 2", Completed: false, Archived: false}
 	list := &TodoList{}
 	assert.Equal(0, list.MaxID())
-	list.Add(todo)
+	list.Add(todo1)
 	assert.Equal(1, list.MaxID())
 	list.Add(todo2)
 	assert.Equal(2, list.MaxID())
@@ -96,18 +97,18 @@ func TestUncomplete(t *testing.T) {
 func TestGarbageCollect(t *testing.T) {
 	assert := assert.New(t)
 	list := &TodoList{}
-	todo := &Todo{Subject: "testing", Completed: false, Archived: true}
-	todo2 := &Todo{Subject: "testing2", Completed: false, Archived: false}
-	todo3 := &Todo{Subject: "testing3", Completed: false, Archived: true}
-	list.Add(todo)
+	todo1 := &Todo{Subject: "testing 1", Completed: false, Archived: true}
+	todo2 := &Todo{Subject: "testing 2", Completed: false, Archived: false}
+	todo3 := &Todo{Subject: "testing 3", Completed: false, Archived: true}
+	list.Add(todo1)
 	list.Add(todo2)
 	list.Add(todo3)
 
 	list.GarbageCollect()
 
 	assert.Equal(len(list.Data), 1)
-	assert.Equal(1, list.NextID())
 	assert.Equal(2, list.MaxID())
+	assert.Equal(3, list.NextID())
 }
 
 func TestPrioritizeNotInTodosJson(t *testing.T) {


### PR DESCRIPTION
At the moment ultralist is setting the NextID to the next free ID available. This is generally speaking working but quite confusing if you have some free IDs because you've deleted todos. By adding a bunch of todos this could result in something like:

```
Todo 10 added.
Todo 21 added.
Todo 23 added.
Todo 24 added.
```
This PR will instead continue with the last MaxID:

```
Todo 24 added.
Todo 25 added.
Todo 26 added.
Todo 27 added.
```

This PR also makes the listing of the IDs a little bit better by adding some offset functionality to show the IDs always at the same level. 