### PR TITLE
Add support for unicode + color flags

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -9,6 +9,8 @@ import (
 )
 
 var (
+	unicodeSupport bool
+	colorSupport   bool
 	listCmdDesc    = "Listing todos including filtering and grouping"
 	listCmdExample = `Filtering by date:
 
@@ -53,7 +55,7 @@ var listCmd = &cobra.Command{
 	Long:    listCmdLongDesc,
 	Short:   listCmdDesc,
 	Run: func(cmd *cobra.Command, args []string) {
-		ultralist.NewApp().ListTodos(strings.Join(args, " "))
+		ultralist.NewAppWithPrintOptions(unicodeSupport, colorSupport).ListTodos(strings.Join(args, " "))
 	},
 }
 
@@ -68,7 +70,7 @@ var listArchivedCmd = &cobra.Command{
 	Long:    listArchivedCmdLongDesc,
 	Short:   listArchivedCmdDesc,
 	Run: func(cmd *cobra.Command, args []string) {
-		ultralist.NewApp().ListTodos("archived")
+		ultralist.NewAppWithPrintOptions(unicodeSupport, colorSupport).ListTodos("archived")
 	},
 }
 
@@ -88,7 +90,7 @@ var listCompletedCmd = &cobra.Command{
 	Long:    listCompletedCmdLongDesc,
 	Short:   listCompletedCmdDesc,
 	Run: func(cmd *cobra.Command, args []string) {
-		ultralist.NewApp().ListTodos("completed " + strings.Join(args, " "))
+		ultralist.NewAppWithPrintOptions(unicodeSupport, colorSupport).ListTodos("completed " + strings.Join(args, " "))
 	},
 }
 
@@ -112,12 +114,12 @@ var listNotesCmd = &cobra.Command{
 		if len(args) > 0 {
 			i, err := strconv.Atoi(args[0])
 			if err == nil {
-				ultralist.NewApp().HandleNotes("n " + strconv.Itoa(i))
+				ultralist.NewAppWithPrintOptions(unicodeSupport, colorSupport).HandleNotes("n " + strconv.Itoa(i))
 			} else {
-				ultralist.NewApp().ListTodos("ln " + strings.Join(args, " "))
+				ultralist.NewAppWithPrintOptions(unicodeSupport, colorSupport).ListTodos("ln " + strings.Join(args, " "))
 			}
 		} else {
-			ultralist.NewApp().ListTodos("ln " + strings.Join(args, " "))
+			ultralist.NewAppWithPrintOptions(unicodeSupport, colorSupport).ListTodos("ln " + strings.Join(args, " "))
 		}
 	},
 }
@@ -133,7 +135,7 @@ var listPrioritizeCmd = &cobra.Command{
 	Long:    listPrioritizeCmdLongDesc,
 	Short:   listPrioritizeCmdDesc,
 	Run: func(cmd *cobra.Command, args []string) {
-		ultralist.NewApp().ListTodos("prioritized " + strings.Join(args, " "))
+		ultralist.NewAppWithPrintOptions(unicodeSupport, colorSupport).ListTodos("prioritized " + strings.Join(args, " "))
 	},
 }
 
@@ -148,12 +150,14 @@ var listOverdueCmd = &cobra.Command{
 	Long:    listOverdueCmdLongDesc,
 	Short:   listOverdueCmdDesc,
 	Run: func(cmd *cobra.Command, args []string) {
-		ultralist.NewApp().ListTodos("overdue " + strings.Join(args, " "))
+		ultralist.NewAppWithPrintOptions(unicodeSupport, colorSupport).ListTodos("overdue " + strings.Join(args, " "))
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(listCmd)
+	listCmd.Flags().BoolVarP(&unicodeSupport, "unicode", "", true, "Allows unicode support in Ultralist output")
+	listCmd.Flags().BoolVarP(&colorSupport, "color", "", true, "Allows color in Ultralist output")
 	listCmd.AddCommand(listArchivedCmd)
 	listCmd.AddCommand(listCompletedCmd)
 	listCmd.AddCommand(listNotesCmd)

--- a/ultralist/app.go
+++ b/ultralist/app.go
@@ -28,7 +28,24 @@ type App struct {
 func NewApp() *App {
 	app := &App{
 		TodoList:  &TodoList{},
-		Printer:   NewScreenPrinter(),
+		Printer:   NewScreenPrinter(true),
+		TodoStore: NewFileStore(),
+	}
+	return app
+}
+
+// NewAppWithPrintOptions creates a new app with options for printing on screen.
+func NewAppWithPrintOptions(unicodeSupport bool, colorSupport bool) *App {
+	var printer Printer
+	if colorSupport {
+		printer = NewScreenPrinter(unicodeSupport)
+	} else {
+		printer = NewSimpleScreenPrinter(unicodeSupport)
+	}
+
+	app := &App{
+		TodoList:  &TodoList{},
+		Printer:   printer,
 		TodoStore: NewFileStore(),
 	}
 	return app

--- a/ultralist/printer.go
+++ b/ultralist/printer.go
@@ -1,5 +1,12 @@
 package ultralist
 
+import "regexp"
+
+var (
+	projectRegex, _ = regexp.Compile(`\+[\p{L}\d_]+`)
+	contextRegex, _ = regexp.Compile(`\@[\p{L}\d_]+`)
+)
+
 // Printer is an interface for printing grouped todos.
 type Printer interface {
 	Print(*GroupedTodos, bool)

--- a/ultralist/screen_printer.go
+++ b/ultralist/screen_printer.go
@@ -2,43 +2,41 @@ package ultralist
 
 import (
 	"io"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 	"text/tabwriter"
+	"time"
 
 	"github.com/cheynewallace/tabby"
 	"github.com/fatih/color"
 )
 
 var (
-	blue            = color.New(0, color.FgBlue)
-	blueBold        = color.New(color.Bold, color.FgBlue)
-	cyan            = color.New(0, color.FgCyan)
-	cyanBold        = color.New(color.Bold, color.FgCyan)
-	magenta         = color.New(0, color.FgMagenta)
-	magentaBold     = color.New(color.Bold, color.FgMagenta)
-	red             = color.New(0, color.FgRed)
-	redBold         = color.New(color.Bold, color.FgRed)
-	white           = color.New(0, color.FgWhite)
-	whiteBold       = color.New(color.Bold, color.FgWhite)
-	yellow          = color.New(0, color.FgYellow)
-	yellowBold      = color.New(color.Bold, color.FgYellow)
-	projectRegex, _ = regexp.Compile(`\+[\p{L}\d_]+`)
-	contextRegex, _ = regexp.Compile(`\@[\p{L}\d_]+`)
+	blue        = color.New(0, color.FgBlue)
+	blueBold    = color.New(color.Bold, color.FgBlue)
+	cyan        = color.New(0, color.FgCyan)
+	cyanBold    = color.New(color.Bold, color.FgCyan)
+	magenta     = color.New(0, color.FgMagenta)
+	magentaBold = color.New(color.Bold, color.FgMagenta)
+	red         = color.New(0, color.FgRed)
+	redBold     = color.New(color.Bold, color.FgRed)
+	white       = color.New(0, color.FgWhite)
+	whiteBold   = color.New(color.Bold, color.FgWhite)
+	yellow      = color.New(0, color.FgYellow)
+	yellowBold  = color.New(color.Bold, color.FgYellow)
 )
 
 // ScreenPrinter is the default struct of this file
 type ScreenPrinter struct {
-	Writer *io.Writer
+	Writer         *io.Writer
+	UnicodeSupport bool
 }
 
 // NewScreenPrinter creates a new screeen printer.
-func NewScreenPrinter() *ScreenPrinter {
+func NewScreenPrinter(unicodeSupport bool) *ScreenPrinter {
 	w := new(io.Writer)
-	formatter := &ScreenPrinter{Writer: w}
+	formatter := &ScreenPrinter{Writer: w, UnicodeSupport: unicodeSupport}
 	return formatter
 }
 
@@ -89,7 +87,11 @@ func (f *ScreenPrinter) formatID(ID int, isPriority bool) string {
 
 func (f *ScreenPrinter) formatCompleted(completed bool) string {
 	if completed {
-		return white.Sprint("[x]")
+		if f.UnicodeSupport {
+			return white.Sprint("[✔]")
+		} else {
+			return white.Sprint("[x]")
+		}
 	}
 	return white.Sprint("[ ]")
 }

--- a/ultralist/simple_screen_printer.go
+++ b/ultralist/simple_screen_printer.go
@@ -1,0 +1,155 @@
+package ultralist
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/cheynewallace/tabby"
+	"github.com/fatih/color"
+)
+
+// ScreenPrinter is the default struct of this file
+type SimpleScreenPrinter struct {
+	Writer         *io.Writer
+	UnicodeSupport bool
+}
+
+// NewScreenPrinter creates a new screeen printer.
+func NewSimpleScreenPrinter(unicodeSupport bool) *SimpleScreenPrinter {
+	w := new(io.Writer)
+	formatter := &SimpleScreenPrinter{Writer: w, UnicodeSupport: unicodeSupport}
+	return formatter
+}
+
+// Print prints the output of ultralist to the terminal screen.
+func (f *SimpleScreenPrinter) Print(groupedTodos *GroupedTodos, printNotes bool) {
+	var keys []string
+	for key := range groupedTodos.Groups {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	tabby := tabby.NewCustom(tabwriter.NewWriter(color.Output, 0, 0, 2, ' ', 0))
+	tabby.AddLine()
+	for _, key := range keys {
+		tabby.AddLine(fmt.Sprint(key))
+		for _, todo := range groupedTodos.Groups[key] {
+			f.printTodo(tabby, todo, printNotes)
+		}
+		tabby.AddLine()
+	}
+	tabby.Print()
+}
+
+func (f *SimpleScreenPrinter) printTodo(tabby *tabby.Tabby, todo *Todo, printNotes bool) {
+	tabby.AddLine(
+		f.formatID(todo.ID, todo.IsPriority),
+		f.formatCompleted(todo.Completed),
+		f.formatDue(todo.Due, todo.IsPriority, todo.Completed),
+		f.formatSubject(todo.Subject, todo.IsPriority))
+	if printNotes {
+		for nid, note := range todo.Notes {
+			tabby.AddLine(
+				"  "+fmt.Sprint(strconv.Itoa(nid)),
+				fmt.Sprint(""),
+				fmt.Sprint(""),
+				fmt.Sprint(""),
+				fmt.Sprint(note))
+		}
+	}
+}
+
+func (f *SimpleScreenPrinter) formatID(ID int, isPriority bool) string {
+	if isPriority {
+		return fmt.Sprint(strconv.Itoa(ID))
+	}
+	return fmt.Sprint(strconv.Itoa(ID))
+}
+
+func (f *SimpleScreenPrinter) formatCompleted(completed bool) string {
+	if completed {
+		if f.UnicodeSupport {
+			return fmt.Sprint("[✔]")
+		} else {
+			return fmt.Sprint("[x]")
+		}
+	}
+	return fmt.Sprint("[ ]")
+}
+
+func (f *SimpleScreenPrinter) formatDue(due string, isPriority bool, completed bool) string {
+	if due == "" {
+		return fmt.Sprint("          ")
+	}
+	dueTime, _ := time.Parse("2006-01-02", due)
+
+	if isPriority {
+		return f.printPriorityDue(dueTime, completed)
+	}
+	return f.printDue(dueTime, completed)
+
+}
+
+func (f *SimpleScreenPrinter) printDue(due time.Time, completed bool) string {
+	if isToday(due) {
+		return fmt.Sprint("today     ")
+	} else if isTomorrow(due) {
+		return fmt.Sprint("tomorrow  ")
+	} else if isPastDue(due) && !completed {
+		return fmt.Sprint(due.Format("Mon Jan 02"))
+	}
+	return fmt.Sprint(due.Format("Mon Jan 02"))
+}
+
+func (f *SimpleScreenPrinter) printPriorityDue(due time.Time, completed bool) string {
+	if isToday(due) {
+		return fmt.Sprint("today     ")
+	} else if isTomorrow(due) {
+		return fmt.Sprint("tomorrow  ")
+	} else if isPastDue(due) && !completed {
+		return fmt.Sprint(due.Format("Mon Jan 02"))
+	}
+	return fmt.Sprint(due.Format("Mon Jan 02"))
+}
+
+func (f *SimpleScreenPrinter) formatSubject(subject string, isPriority bool) string {
+	splitted := strings.Split(subject, " ")
+
+	if isPriority {
+		return f.printPrioritySubject(splitted)
+	}
+	return f.printSubject(splitted)
+}
+
+func (f *SimpleScreenPrinter) printPrioritySubject(splitted []string) string {
+	coloredWords := []string{}
+	for _, word := range splitted {
+		if projectRegex.MatchString(word) {
+			coloredWords = append(coloredWords, fmt.Sprint(word))
+		} else if contextRegex.MatchString(word) {
+			coloredWords = append(coloredWords, fmt.Sprint(word))
+		} else {
+			coloredWords = append(coloredWords, fmt.Sprint(word))
+		}
+	}
+	return strings.Join(coloredWords, " ")
+}
+
+func (f *SimpleScreenPrinter) printSubject(splitted []string) string {
+	coloredWords := []string{}
+	for _, word := range splitted {
+		if projectRegex.MatchString(word) {
+			coloredWords = append(coloredWords, fmt.Sprint(word))
+		} else if contextRegex.MatchString(word) {
+			coloredWords = append(coloredWords, fmt.Sprint(word))
+		} else {
+			coloredWords = append(coloredWords, fmt.Sprint(word))
+		}
+	}
+	return strings.Join(coloredWords, " ")
+}


### PR DESCRIPTION
This change does 2 things:

* Changes the default completed character from `[x]` to `[✔]`
* Adds a `--color` flag, which is `true` by default.
* Adds a `--unicode` flag, which is `true` by default.

Adds a `SimpleScreenPrinter`, which will print a task list without using any colors.