### PR TITLE
gitignore: don't ignore go.mod file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .goxc.local.json
-go.mod
 dist
 
 # OSX metadata


### PR DESCRIPTION
This file should be checked out into source control alongside `go.sum`.