### PR TITLE
Fixed an input bug, where due (next|last) week is not captured by a regex

### DIFF
--- a/ultralist/parser.go
+++ b/ultralist/parser.go
@@ -168,7 +168,8 @@ func (p *Parser) hasDue(input string) bool {
 	r1, _ := regexp.Compile(`due \w+$`)
 	r2, _ := regexp.Compile(`due \w+ \d+$`)
 	r3, _ := regexp.Compile(`due \d+ \w+$`)
-	return (r1.MatchString(input) || r2.MatchString(input) || r3.MatchString(input))
+	r4, _ := regexp.Compile(`due (last|next) week$`)
+	return (r1.MatchString(input) || r2.MatchString(input) || r3.MatchString(input) || r4.MatchString(input))
 }
 
 // Due is returning the the due date of a todo.

--- a/ultralist/parser_test.go
+++ b/ultralist/parser_test.go
@@ -25,6 +25,32 @@ func TestParseSubjectWithDue(t *testing.T) {
 	}
 }
 
+func TestParseSubjectWithDueNextWeek(t *testing.T) {
+	assert := assert.New(t)
+	parser := &Parser{}
+	todo := parser.ParseNewTodo("do this thing due next week")
+	if todo.Subject != "do this thing" {
+		t.Error("Expected todo.Subject to equal 'do this thing', got ", todo.Subject)
+	}
+
+	expectedDate := parser.Due("due next week", time.Now())
+	assert.Equal(expectedDate, todo.Due)
+	assert.NotNil(todo.Due)
+}
+
+func TestParseSubjectWithDueLastWeek(t *testing.T) {
+	assert := assert.New(t)
+	parser := &Parser{}
+	todo := parser.ParseNewTodo("do this thing due last week")
+	if todo.Subject != "do this thing" {
+		t.Error("Expected todo.Subject to equal 'do this thing', got ", todo.Subject)
+	}
+
+	expectedDate := parser.Due("due last week", time.Now())
+	assert.Equal(expectedDate, todo.Due)
+	assert.NotNil(todo.Due)
+}
+
 func TestParseExpandProjects(t *testing.T) {
 	assert := assert.New(t)
 	parser := &Parser{}


### PR DESCRIPTION
Hi @gammons 

It has been a while.

Here is my fix for #126, it seems the regex that detects due, does not detect  and thus not setting a todo's due date.

AS always happy to add to this as you need.

Regards

Stuart

