### PR TITLE
Update the sync command

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -6,16 +6,30 @@ import (
 )
 
 var (
-	syncCmdDesc     = "Sync a list with ultralist.io"
-	syncCmdExample  = "ultralist sync"
+	syncCmdDesc    = "Sync a list with ultralist.io"
+	syncCmdExample = `ultralist sync
+ultralist sync --setup
+ultralist sync --unsync
+ultralist sync --quiet
+`
+
 	syncCmdQuiet    bool
-	syncCmdLongDesc = `
+	setupCmd        bool
+	unsyncCmd       bool
+	syncCmdLongDesc = `Sync a list with Ultralist Pro.
 
-The sync command has a few uses:
-* If you are logged into ultralist.io (via "ultralist auth"), you can sync an existing list using "ultralist sync".
-* For a synced list, you can run "ultralist sync" explicitly to receive any changes that may have occurred elsewhere.
+ultralist sync
+  The Ultralist CLI stores tasks locally.  When running sync, it will push
+  up any local changes to ultralist.io, as well as pulling down any remote changes from ultralist.io.
 
-Local changes to a synced list automatically get pushed to ultralist.io.
+ultralist sync --setup
+  Set up the local list to sync with ultralist.io.  Or, pull a list from Ultralist.io to local.
+
+ultralist sync --unsync
+  Stop syncing a local list with ultralist.io.
+
+ultralist sync --quiet
+  Perform a sync without showing output to the screen.
 
 See https://ultralist.io/docs/cli/pro_integration for more info.
 `
@@ -27,11 +41,22 @@ var syncCmd = &cobra.Command{
 	Long:    syncCmdLongDesc,
 	Short:   syncCmdDesc,
 	Run: func(cmd *cobra.Command, args []string) {
+		if setupCmd {
+			ultralist.NewApp().SetupSync()
+			return
+		}
+		if unsyncCmd {
+			ultralist.NewApp().Unsync()
+			return
+		}
+
 		ultralist.NewApp().Sync(syncCmdQuiet)
 	},
 }
 
 func init() {
 	syncCmd.Flags().BoolVarP(&syncCmdQuiet, "quiet", "q", false, "Run without output")
+	syncCmd.Flags().BoolVarP(&setupCmd, "setup", "", false, "Set up a list to sync with ultralist.io, or pull a remote list to local")
+	syncCmd.Flags().BoolVarP(&unsyncCmd, "unsync", "", false, "Stop syncing a list with ultralist.io")
 	rootCmd.AddCommand(syncCmd)
 }

--- a/ultralist/app.go
+++ b/ultralist/app.go
@@ -337,14 +337,14 @@ func (a *App) SetupSync() {
 		return
 	}
 
-	a.Load()
-
-	if a.TodoList.IsSynced {
-		fmt.Println("This list is already sycned with ultralist.io. Use the --unsync flag to stop syncing this list.")
-		return
-	}
-
 	if a.TodoStore.LocalTodosFileExists() {
+		a.Load()
+
+		if a.TodoList.IsSynced {
+			fmt.Println("This list is already sycned with ultralist.io. Use the --unsync flag to stop syncing this list.")
+			return
+		}
+
 		prompt := promptui.Select{
 			Label: "You have a todos list in this directory.  What would you like to do?",
 			Items: []string{"Sync my list to ultralist.io", "Pull a list from ultralist.io, replacing the list that's here"},
@@ -390,10 +390,12 @@ func (a *App) SetupSync() {
 	}
 
 	idx, _, _ := prompt2.Run()
-	a.EventLogger.CurrentSyncedList.Name = response.Todolists[idx].Name
-	a.EventLogger.CurrentSyncedList.UUID = response.Todolists[idx].UUID
+	// a.EventLogger.CurrentSyncedList.Name = response.Todolists[idx].Name
+	// a.EventLogger.CurrentSyncedList.UUID = response.Todolists[idx].UUID
 	a.TodoList = &response.Todolists[idx]
-	a.save()
+	a.TodoStore.Save(a.TodoList.Data)
+
+	a.EventLogger = NewEventLogger(a.TodoList, a.TodoStore)
 	a.EventLogger.WriteSyncedLists()
 }
 

--- a/ultralist/event_logger.go
+++ b/ultralist/event_logger.go
@@ -145,6 +145,17 @@ func (e *EventLogger) initializeSyncedList() {
 	e.CurrentSyncedList = list
 }
 
+// DeleteCurrentSyncedList - delete a synced list from the synced_lists.json file
+func (e *EventLogger) DeleteCurrentSyncedList() {
+	var syncedListsWithoutDeleted []*SyncedList
+	for _, list := range e.SyncedLists {
+		if list.UUID != e.CurrentSyncedList.UUID {
+			syncedListsWithoutDeleted = append(syncedListsWithoutDeleted, list)
+		}
+	}
+	e.SyncedLists = syncedListsWithoutDeleted
+}
+
 // WriteSyncedLists is writing a synced list.
 func (e *EventLogger) WriteSyncedLists() {
 	data, _ := json.Marshal(e.SyncedLists)

--- a/ultralist/file_store.go
+++ b/ultralist/file_store.go
@@ -7,29 +7,26 @@ import (
 	"os"
 )
 
+// the filename to use
+const FILENAME = ".todos.json"
+
 // FileStore is the main struct of this file.
 type FileStore struct {
-	FileLocation string
-	Loaded       bool
+	Loaded bool
 }
 
 // NewFileStore is creating a new file store.
 func NewFileStore() *FileStore {
-	return &FileStore{FileLocation: "", Loaded: false}
+	return &FileStore{Loaded: false}
 }
 
 // Initialize is initializing a new .todos.json file.
 func (f *FileStore) Initialize() {
-	if f.FileLocation == "" {
-		f.FileLocation = ".todos.json"
-	}
-
-	_, err := ioutil.ReadFile(f.FileLocation)
-	if err == nil {
+	if f.LocalTodosFileExists() {
 		fmt.Println("It looks like a .todos.json file already exists!  Doing nothing.")
 		os.Exit(0)
 	}
-	if err := ioutil.WriteFile(f.FileLocation, []byte("[]"), 0644); err != nil {
+	if err := ioutil.WriteFile(FILENAME, []byte("[]"), 0644); err != nil {
 		fmt.Println("Error writing json file", err)
 		os.Exit(1)
 	}
@@ -46,13 +43,9 @@ func (f *FileStore) LocalTodosFileExists() bool {
 	return true
 }
 
-// Load is loading a .todos.json file.
+// Load is loading a .todos.json file, either from cwd, or the home directory
 func (f *FileStore) Load() ([]*Todo, error) {
-	if f.FileLocation == "" {
-		f.FileLocation = f.GetLocation()
-	}
-
-	data, err := ioutil.ReadFile(f.FileLocation)
+	data, err := ioutil.ReadFile(f.GetLocation())
 	if err != nil {
 		fmt.Println("No todo file found!")
 		fmt.Println("Initialize a new todo repo by running 'ultralist init'")
@@ -82,20 +75,15 @@ func (f *FileStore) Save(todos []*Todo) {
 	}
 
 	data, _ := json.Marshal(todos)
-	if err := ioutil.WriteFile(f.FileLocation, []byte(data), 0644); err != nil {
+	if err := ioutil.WriteFile(FILENAME, []byte(data), 0644); err != nil {
 		fmt.Println("Error writing json file", err)
 	}
 }
 
 // GetLocation is returning the location of the .todos.json file.
 func (f *FileStore) GetLocation() string {
-	dir, _ := os.Getwd()
-	localrepo := fmt.Sprintf("%s/.todos.json", dir)
-	_, ferr := os.Stat(localrepo)
-	if ferr == nil {
-		return localrepo
+	if f.LocalTodosFileExists() {
+		return FILENAME
 	}
-
-	home := UserHomeDir()
-	return fmt.Sprintf("%s/.todos.json", home)
+	return fmt.Sprintf("%s/.todos.json", UserHomeDir())
 }

--- a/ultralist/file_store.go
+++ b/ultralist/file_store.go
@@ -35,6 +35,17 @@ func (f *FileStore) Initialize() {
 	}
 }
 
+// Returns if a local .todos.json file exists in the current dir.
+func (f *FileStore) LocalTodosFileExists() bool {
+	dir, _ := os.Getwd()
+	localrepo := fmt.Sprintf("%s/.todos.json", dir)
+	_, err := os.Stat(localrepo)
+	if err != nil {
+		return false
+	}
+	return true
+}
+
 // Load is loading a .todos.json file.
 func (f *FileStore) Load() ([]*Todo, error) {
 	if f.FileLocation == "" {

--- a/ultralist/file_store.go
+++ b/ultralist/file_store.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 )
 
-// the filename to use
-const FILENAME = ".todos.json"
+// TodosJSONFile is the filename to store todos in
+const TodosJSONFile = ".todos.json"
 
 // FileStore is the main struct of this file.
 type FileStore struct {
@@ -26,7 +27,7 @@ func (f *FileStore) Initialize() {
 		fmt.Println("It looks like a .todos.json file already exists!  Doing nothing.")
 		os.Exit(0)
 	}
-	if err := ioutil.WriteFile(FILENAME, []byte("[]"), 0644); err != nil {
+	if err := ioutil.WriteFile(TodosJSONFile, []byte("[]"), 0644); err != nil {
 		fmt.Println("Error writing json file", err)
 		os.Exit(1)
 	}
@@ -35,7 +36,7 @@ func (f *FileStore) Initialize() {
 // Returns if a local .todos.json file exists in the current dir.
 func (f *FileStore) LocalTodosFileExists() bool {
 	dir, _ := os.Getwd()
-	localrepo := fmt.Sprintf("%s/.todos.json", dir)
+	localrepo := filepath.Join(dir, TodosJSONFile)
 	_, err := os.Stat(localrepo)
 	if err != nil {
 		return false
@@ -75,7 +76,7 @@ func (f *FileStore) Save(todos []*Todo) {
 	}
 
 	data, _ := json.Marshal(todos)
-	if err := ioutil.WriteFile(FILENAME, []byte(data), 0644); err != nil {
+	if err := ioutil.WriteFile(TodosJSONFile, []byte(data), 0644); err != nil {
 		fmt.Println("Error writing json file", err)
 	}
 }
@@ -83,7 +84,7 @@ func (f *FileStore) Save(todos []*Todo) {
 // GetLocation is returning the location of the .todos.json file.
 func (f *FileStore) GetLocation() string {
 	if f.LocalTodosFileExists() {
-		return FILENAME
+		return TodosJSONFile
 	}
-	return fmt.Sprintf("%s/.todos.json", UserHomeDir())
+	return fmt.Sprintf("%s/%s", UserHomeDir(), TodosJSONFile)
 }

--- a/ultralist/file_store_test.go
+++ b/ultralist/file_store_test.go
@@ -9,13 +9,12 @@ import (
 func TestFileStore(t *testing.T) {
 	assert := assert.New(t)
 	list := SetUpTestMemoryTodoList()
-	testFilename := "TestFileStore_todos.json"
-	store := &FileStore{FileLocation: testFilename}
-	defer testFileCleanUp(testFilename)
+	store := &FileStore{}
+	defer testFileCleanUp()
 	list.FindByID(2).Subject = "this is an non-fixture subject"
 	store.Save(list.Todos())
 
-	store1 := &FileStore{FileLocation: testFilename}
+	store1 := &FileStore{}
 
 	todos, _ := store1.Load()
 	assert.Equal(todos[1].Subject, "this is the first subject", "")

--- a/ultralist/memory_store.go
+++ b/ultralist/memory_store.go
@@ -18,6 +18,10 @@ func (m *MemoryStore) Load() ([]*Todo, error) {
 	return m.Todos, nil
 }
 
+func (m *MemoryStore) LocalTodosFileExists() bool {
+	return false
+}
+
 // Save is saving todos to the memory store.
 func (m *MemoryStore) Save(todos []*Todo) {
 	m.Todos = todos

--- a/ultralist/store.go
+++ b/ultralist/store.go
@@ -3,6 +3,7 @@ package ultralist
 // Store is the interface for ultralist todos.
 type Store interface {
 	GetLocation() string
+	LocalTodosFileExists() bool
 	Initialize()
 	Load() ([]*Todo, error)
 	Save(todos []*Todo)

--- a/ultralist/todo_test.go
+++ b/ultralist/todo_test.go
@@ -50,8 +50,8 @@ func SetUpTestMemoryTodoList() *TodoList {
 	return list
 }
 
-func testFileCleanUp(filename string) {
-	var err = os.Remove(filename)
+func testFileCleanUp() {
+	var err = os.Remove(TodosJSONFile)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Previously, setting up a list to sync with ultralist.io was fairly convoluted.  Bot the `init` and `sync` commands were dependent on a list's sync state, and the behavior of these commands would change based upon that.

**Previous flow:**

* `ultralist init` - Create a new list and optionally, sync it with Ultralist.io.
* `ultralist sync` - Depending if a list is synced or not, it does multiple things:
  * If not synced, sets up the local list to sync to ultralist.io.
  * If is already synced, pull remote changes to local, and push any local changes to remote.

This PR simplifies the commands by adding a couple of flags to the `sync` command.  The result is that each command has one job to do, instead of many dependent on state.  It's simpler to understand as well.

**With this PR:**

* `ultralist init` - makes this command do just one thing - initialize a list.  It does not handle syncing a list as well.
* `ultralist sync --setup` - sets up a local list to sync with ultralist.io, or pulls a list from ultralist.io and replaces what's local.
* `ultralist sync --unsync` - stops a local list from syncing with ultralist.io.
* `ultralist sync` - just handles the actual list syncing between local and ultralist.io.