### PR TITLE
prevent segfault when authing

### DIFF
--- a/ultralist/webapp.go
+++ b/ultralist/webapp.go
@@ -45,7 +45,7 @@ func (w *Webapp) handleAuthResponse(writer http.ResponseWriter, r *http.Request)
 	// sleep 1 second before shutting server down, so we can display msg on web.
 	go func() {
 		time.Sleep(1 * time.Second)
-		w.server.Shutdown(nil)
+		os.Exit(0)
 	}()
 }
 


### PR DESCRIPTION
This LOC was causing an occasional segault (possibly a race condition?). 

In this part of the code, it's on it's way towards exiting completely, so I don't think the `Shutdown` task is necessary.  Especially considering the only connection it's handling is one single connection from the user.