### PR TITLE
Fix bug with syncing todos

### DIFF
--- a/ultralist/app.go
+++ b/ultralist/app.go
@@ -59,7 +59,7 @@ func (a *App) InitializeRepo() {
 	fmt.Println("Repo initialized.")
 }
 
-// AddTodo is adding a new todo.
+// AddTodo adds a new todo to the current list
 func (a *App) AddTodo(input string) {
 	a.load()
 	parser := &InputParser{}

--- a/ultralist/file_store.go
+++ b/ultralist/file_store.go
@@ -73,7 +73,7 @@ func (f *FileStore) Save(todos []*Todo) {
 	}
 
 	data, _ := json.Marshal(todos)
-	if err := ioutil.WriteFile(TodosJSONFile, []byte(data), 0644); err != nil {
+	if err := ioutil.WriteFile(f.GetLocation(), []byte(data), 0644); err != nil {
 		fmt.Println("Error writing json file", err)
 	}
 }


### PR DESCRIPTION
closes #219 

You must have a synced list for this bug to be replicable.

If you have a `.todos.json` file in your home dir, and add a todo to it
in a subdirectory, it would end up creating a `.todos.json` file in the
subdirectory, rather than adding it to the `.todos.json` in the home
dir.