### PR TITLE
update the synchronizer to use same code path as frontend

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,37 @@
+name: Go
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+        if [ -f Gopkg.toml ]; then
+            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+            dep ensure
+        fi
+
+    - name: Build
+      run: go build -v .
+
+    - name: Test
+      run: go test -v .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
         fi
 
     - name: Build
-      run: go build -v .
+      run: go build -v -o /tmp/ultralist .
 
     - name: Test
-      run: go test -v .
+      run: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ### Simple task management for tech folks.
 
 [![](https://goreportcard.com/badge/github.com/ultralist/ultralist)](https://goreportcard.com/report/github.com/ultralist/ultralist)
-[![Build Status](https://travis-ci.org/ultralist/ultralist.svg?branch=master)](https://travis-ci.org/ultralist/ultralist)
+[![Actions Status](https://github.com/ultralist/ultralist/workflows/Go/badge.svg)](https://github.com/ultralist/ultralist/actions)
 
 Ultralist is a task management system for technical people. It is command-line component that is very fast and stays out of the way. 
 

--- a/ultralist/app.go
+++ b/ultralist/app.go
@@ -342,9 +342,13 @@ func (a *App) SetupSync() {
 				return
 			}
 			a.EventLogger.CurrentSyncedList.Name = result
+			a.TodoList.Name = result
 			a.TodoList.IsSynced = true
 			a.EventLogger.WriteSyncedLists()
-			a.Sync(false)
+
+			// right here, I need to run a request to create a todo list via the API.
+			backend.CreateTodoList(a.TodoList)
+
 			return
 		}
 	}

--- a/ultralist/backend.go
+++ b/ultralist/backend.go
@@ -32,6 +32,17 @@ func NewBackend() *Backend {
 	return backend
 }
 
+// CreateTodoList will create a todo list on the backend
+func (b *Backend) CreateTodoList(todolist *TodoList) {
+	type Request struct {
+		Todolist *TodoList `json:"todolist"`
+	}
+
+	bodyBytes, _ := json.Marshal(&Request{Todolist: todolist})
+
+	b.PerformRequest("POST", "/api/v1/todo_lists", bodyBytes)
+}
+
 // PerformRequest is performing a request to the ultralist API backend.
 func (b *Backend) PerformRequest(method string, path string, data []byte) []byte {
 	url := b.apiURL(path)

--- a/ultralist/event_logger.go
+++ b/ultralist/event_logger.go
@@ -139,6 +139,7 @@ func (e *EventLogger) initializeSyncedListFromCurrentTodoList() {
 	listUUID := e.CurrentTodoList.UUID
 	if listUUID == "" {
 		listUUID = newUUID()
+		e.CurrentTodoList.UUID = listUUID
 	}
 
 	list := &SyncedList{

--- a/ultralist/event_logger_test.go
+++ b/ultralist/event_logger_test.go
@@ -19,7 +19,7 @@ func TestCreateEventLogsWithAddingTodo(t *testing.T) {
 
 	assert.Equal(1, len(logger.Events))
 	assert.Equal(AddEvent, logger.Events[0].EventType)
-	assert.Equal(todo2.ID, logger.Events[0].ID)
+	assert.Equal(todo2.ID, logger.Events[0].Object.ID)
 }
 
 func TestCreateEventLogsWithAddingMultipleTodos(t *testing.T) {
@@ -37,9 +37,9 @@ func TestCreateEventLogsWithAddingMultipleTodos(t *testing.T) {
 
 	assert.Equal(2, len(logger.Events))
 	assert.Equal(AddEvent, logger.Events[0].EventType)
-	assert.Equal(todo2.ID, logger.Events[0].ID)
+	assert.Equal(todo2.ID, logger.Events[0].Object.ID)
 	assert.Equal(AddEvent, logger.Events[1].EventType)
-	assert.Equal(todo3.ID, logger.Events[1].ID)
+	assert.Equal(todo3.ID, logger.Events[1].Object.ID)
 }
 
 func TestUpdateEvent(t *testing.T) {
@@ -54,7 +54,7 @@ func TestUpdateEvent(t *testing.T) {
 
 	assert.Equal(1, len(logger.Events))
 	assert.Equal(UpdateEvent, logger.Events[0].EventType)
-	assert.Equal(todo.ID, logger.Events[0].ID)
+	assert.Equal(todo.ID, logger.Events[0].Object.ID)
 }
 
 func TestDeleteEvent(t *testing.T) {
@@ -71,5 +71,5 @@ func TestDeleteEvent(t *testing.T) {
 
 	assert.Equal(1, len(logger.Events))
 	assert.Equal(DeleteEvent, logger.Events[0].EventType)
-	assert.Equal(todo.ID, logger.Events[0].ID)
+	assert.Equal(todo.ID, logger.Events[0].Object.ID)
 }

--- a/ultralist/file_store_test.go
+++ b/ultralist/file_store_test.go
@@ -12,6 +12,7 @@ func TestFileStore(t *testing.T) {
 	store := &FileStore{}
 	defer testFileCleanUp()
 	list.FindByID(2).Subject = "this is an non-fixture subject"
+	store.Initialize()
 	store.Save(list.Todos())
 
 	store1 := &FileStore{}

--- a/ultralist/synchronizer.go
+++ b/ultralist/synchronizer.go
@@ -129,7 +129,7 @@ func (s *Synchronizer) doSync(todolist *TodoList, syncedList *SyncedList) {
 	// from various clients.
 
 	path = "/api/v1/todo_lists/" + syncedList.UUID
-	bodyBytes := s.Backend.PerformRequest("GET", path, data)
+	bodyBytes := s.Backend.PerformRequest("GET", path, []byte{})
 
 	var response *TodolistRequest
 	if err := json.Unmarshal(bodyBytes, &response); err != nil {

--- a/ultralist/todo_filter.go
+++ b/ultralist/todo_filter.go
@@ -62,7 +62,7 @@ func (f *TodoFilter) ApplyFilter() []*Todo {
 			todoTime, _ := time.Parse(DATE_FORMAT, todo.Due)
 			dueBeforeTime, _ := time.Parse(DATE_FORMAT, f.Filter.DueBefore)
 
-			if !todoTime.Before(dueBeforeTime) {
+			if todo.Due == "" || !todoTime.Before(dueBeforeTime) {
 				continue
 			}
 		}
@@ -71,7 +71,7 @@ func (f *TodoFilter) ApplyFilter() []*Todo {
 			todoTime, _ := time.Parse(DATE_FORMAT, todo.Due)
 			dueAfterTime, _ := time.Parse(DATE_FORMAT, f.Filter.DueAfter)
 
-			if !todoTime.After(dueAfterTime) {
+			if todo.Due == "" || !todoTime.After(dueAfterTime) {
 				continue
 			}
 		}

--- a/ultralist/todo_item.go
+++ b/ultralist/todo_item.go
@@ -17,10 +17,10 @@ type Todo struct {
 	Contexts      []string `json:"contexts"`
 	Due           string   `json:"due"`
 	Completed     bool     `json:"completed"`
-	CompletedDate string   `json:"completedDate"`
+	CompletedDate string   `json:"completed_date"`
 	Status        string   `json:"status"`
 	Archived      bool     `json:"archived"`
-	IsPriority    bool     `json:"isPriority"`
+	IsPriority    bool     `json:"is_priority"`
 	Notes         []string `json:"notes"`
 }
 

--- a/ultralist/webapp.go
+++ b/ultralist/webapp.go
@@ -38,7 +38,7 @@ func (w *Webapp) handleAuthResponse(writer http.ResponseWriter, r *http.Request)
 
 	backend := NewBackend()
 	backend.WriteCreds(cliTokens[0])
-	fmt.Println("Authorization successful! Next, run `ultralist init` to sync a list.")
+	fmt.Println("Authorization successful! Next, run `ultralist sync --setup` to sync a list.")
 
 	http.Redirect(writer, r, w.frontendUrl(), http.StatusSeeOther)
 


### PR DESCRIPTION
With this change, the ultralist CLI will use the same code path for event reconciliation as the frontend.  This will eliminate the need for 2 separate reconciliation code paths.