### PR TITLE
re-add up, uc, and uar as primary commands

### DIFF
--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -8,42 +8,50 @@ import (
 )
 
 var (
-	revertArchivedTodo bool
-	archiveCmdDesc     = "Archives todos"
-	archiveCmdExample  = `  ultralist archive 33
-  Archives todo with id 33.
+	archiveCmdDesc    = "Archives and un-archives todos"
+	archiveCmdExample = `
+  ultralist archive 33
+  ultralist ar 33
+    Archives todo with id 33.
 
-  ultralist archive 33 --revert
-  Unarchives todo with id 33.`
-	archiveCmdLongDesc = archiveCmdDesc + "."
+  ultralist unarchive 33
+  ultralist uar 33
+    Unarchives todo with id 33.
+
+  ultralist archive completed
+  ultralist ar c
+	  archives all completed todos
+
+  ultralist archive gc
+  ultralist ar gc
+	  Run garbage collection. Delete all archived todos and reclaim ids`
 )
 
 var archiveCmd = &cobra.Command{
 	Use:     "archive [id]",
 	Aliases: []string{"ar"},
 	Example: archiveCmdExample,
-	Long:    archiveCmdLongDesc,
-	Short:   archiveCmdDesc,
+	Short:   "Archives a todo",
 	Run: func(cmd *cobra.Command, args []string) {
-		if revertArchivedTodo {
-			ultralist.NewApp().UnarchiveTodo(strings.Join(args, " "))
-		} else {
-			ultralist.NewApp().ArchiveTodo(strings.Join(args, " "))
-		}
+		ultralist.NewApp().ArchiveTodo(strings.Join(args, " "))
 	},
 }
 
-var (
-	archiveCompletedCmdDesc     = "Archives all completed todos"
-	archiveCompletedCmdLongDesc = archiveCompletedCmdDesc + "."
-)
+var unarchiveCmd = &cobra.Command{
+	Use:     "unarchive [id]",
+	Aliases: []string{"aar"},
+	Example: archiveCmdExample,
+	Short:   "Un-archives a todo",
+	Run: func(cmd *cobra.Command, args []string) {
+		ultralist.NewApp().UnarchiveTodo(strings.Join(args, " "))
+	},
+}
 
 var archiveCompletedCmd = &cobra.Command{
 	Use:     "completed",
 	Aliases: []string{"c"},
 	Example: "ultralist archive completed",
-	Long:    archiveCompletedCmdLongDesc,
-	Short:   archiveCompletedCmdDesc,
+	Short:   "Achives all completed todos",
 	Run: func(cmd *cobra.Command, args []string) {
 		ultralist.NewApp().ArchiveCompleted()
 	},
@@ -57,8 +65,7 @@ var (
 var archiveGarbageCollectCmd = &cobra.Command{
 	Use:     "garbage-collect",
 	Aliases: []string{"gc", "rm"},
-	Long:    archiveGarbageCollectCmdLongDesc,
-	Short:   archiveGarbageCollectCmdDesc,
+	Short:   "Deletes all archived todos",
 	Run: func(cmd *cobra.Command, args []string) {
 		ultralist.NewApp().GarbageCollect()
 	},
@@ -66,7 +73,7 @@ var archiveGarbageCollectCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(archiveCmd)
-	archiveCmd.Flags().BoolVarP(&revertArchivedTodo, "revert", "", false, "Unarchives an archived todo")
+	rootCmd.AddCommand(unarchiveCmd)
 	archiveCmd.AddCommand(archiveCompletedCmd)
 	archiveCmd.AddCommand(archiveGarbageCollectCmd)
 }

--- a/cmd/complete.go
+++ b/cmd/complete.go
@@ -9,36 +9,41 @@ import (
 
 var (
 	archiveCompletedTodo bool
-	revertCompletedTodo  bool
-	completeCmdDesc      = "Completes a todo"
-	completeCmdExample   = `  ultralist complete 33
-  Completes todo with id 33.
+	completeCmdExample   = `
+  ultralist complete 33
+  ultralist c 33
+    Completes todo with id 33.
 
-  ultralist complete 33 --archive
-  Completes todo with id 33 and archives it.
+  ultralist uncomplete 33 --archive
+    Completes todo with id 33 and archives it.
 
-  ultralist complete 33 --revert
-  Uncompletes todo with id 33.`
-	completeCmdLongDesc = completeCmdDesc + "."
+  ultralist uncomplete 33
+	ultralist uc 33
+    Uncompletes todo with id 33.`
 )
 
 var completeCmd = &cobra.Command{
 	Use:     "complete [id]",
 	Aliases: []string{"c"},
 	Example: completeCmdExample,
-	Long:    completeCmdLongDesc,
-	Short:   completeCmdDesc,
+	Short:   "Completes a todo.",
 	Run: func(cmd *cobra.Command, args []string) {
-		if revertCompletedTodo {
-			ultralist.NewApp().UncompleteTodo(strings.Join(args, " "))
-		} else {
-			ultralist.NewApp().CompleteTodo(strings.Join(args, " "), archiveCompletedTodo)
-		}
+		ultralist.NewApp().CompleteTodo(strings.Join(args, " "), archiveCompletedTodo)
+	},
+}
+
+var uncompleteCmd = &cobra.Command{
+	Use:     "uncomplete [id]",
+	Aliases: []string{"uc"},
+	Example: completeCmdExample,
+	Short:   "Un-completes a todo.",
+	Run: func(cmd *cobra.Command, args []string) {
+		ultralist.NewApp().UncompleteTodo(strings.Join(args, " "))
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(completeCmd)
 	completeCmd.Flags().BoolVarP(&archiveCompletedTodo, "archive", "", false, "Archives a completed todo automatically")
-	completeCmd.Flags().BoolVarP(&revertCompletedTodo, "revert", "", false, "Uncompletes a completed todo")
+	rootCmd.AddCommand(uncompleteCmd)
 }

--- a/cmd/prioritize.go
+++ b/cmd/prioritize.go
@@ -8,16 +8,17 @@ import (
 )
 
 var (
-	revertPrioritizedTodo bool
-	prioritizeCmdDesc     = "Prioritize and unprioritize todos"
-	prioritizeCmdExample  = `  ultralist prioritize 33
-  Prioritizes todo with id 33.
+	prioritizeCmdExample = `
+  ultralist prioritize 33
+  ultralist p 33
+    Prioritizes todo with id 33.
 
-  ultralist prioritize 33 --revert
-  Unprioritizes todo with id 33.`
+  ultralist unprioritize 33
+  ultralist up 33
+    Unprioritizes todo with id 33.`
 	prioritizeCmdLongDesc = `Prioritize and unprioritize todos.
 
-Todos with a priority flag will be highlighted on top of a list.`
+Todos with a priority flag will be highlighted on top of the list.`
 )
 
 var prioritizeCmd = &cobra.Command{
@@ -25,17 +26,24 @@ var prioritizeCmd = &cobra.Command{
 	Aliases: []string{"p"},
 	Example: prioritizeCmdExample,
 	Long:    prioritizeCmdLongDesc,
-	Short:   prioritizeCmdDesc,
+	Short:   "Prioritize a todo",
 	Run: func(cmd *cobra.Command, args []string) {
-		if revertArchivedTodo {
-			ultralist.NewApp().UnprioritizeTodo(strings.Join(args, " "))
-		} else {
-			ultralist.NewApp().PrioritizeTodo(strings.Join(args, " "))
-		}
+		ultralist.NewApp().PrioritizeTodo(strings.Join(args, " "))
+	},
+}
+
+var unprioritizeCmd = &cobra.Command{
+	Use:     "unprioritize [id]",
+	Aliases: []string{"up"},
+	Example: prioritizeCmdExample,
+	Long:    prioritizeCmdLongDesc,
+	Short:   "Un-prioritize a todo",
+	Run: func(cmd *cobra.Command, args []string) {
+		ultralist.NewApp().UnprioritizeTodo(strings.Join(args, " "))
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(prioritizeCmd)
-	prioritizeCmd.Flags().BoolVarP(&revertArchivedTodo, "revert", "", false, "Unprioritizes an prioritized todo")
+	rootCmd.AddCommand(unprioritizeCmd)
 }


### PR DESCRIPTION
This removes the `--revert` option, and re-adds new primary commands that were formerly deleted:

`up` - un-prioritize a task
`uar` - un-archive a task
`uc` - un-complete a task

This makes things a bit handier to use rather than using a `--revert` option.