### PR TITLE
Improve version output

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -17,7 +17,7 @@ var versionCmd = &cobra.Command{
 	Long:  versionCmdLongDesc,
 	Short: versionCmdDesc,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("Ultralist v%s.", ultralist.VERSION)
+		fmt.Printf("Ultralist v%s\n", ultralist.VERSION)
 	},
 }
 


### PR DESCRIPTION
When executing a `ultralist version`, I get following output

```
$ ultralist version
Ultralist v1.6.2.%
```

By adding a newline to the `fmt.Printf`, the `%` sign is not longer shown.
