### PR TITLE
Recurrence

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -27,11 +27,10 @@ func init() {
   See the full docs at https://ultralist.io/docs/cli/managing_tasks/#adding-todos
 
   Todos can also recur.  Set the 'recur' directive to control recurrence:
-
     ultralist a Daily standup recur:weekdays
     ultralist a 1o1 meeting with jim recur:weekly
 
-  For full documentation on recurrence, see:
+  For the full documentation on recurrence, see the docs:
   https://ultralist.io/docs/cli/recurrence`
 	)
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -10,9 +10,10 @@ import (
 func init() {
 	var (
 		addCmdDesc    = "Adds todos"
-		addCmdExample = `  ultralist add Prepare meeting notes about +importantProject for the meeting with @bob due today
-  ultralist add Meeting with @bob about +importantProject due:today
-  ultralist add +work +verify did @john fix the build? due:tom`
+		addCmdExample = `  ultralist add Prepare meeting notes about +importantProject for the meeting with @bob due:today
+  ultralist add Meeting with @bob about +project due:tod
+  ultralist a +work +verify did @john fix the build? due:tom
+  ultralist a here is an important task priority:true recur:weekdays due:tom`
 
 		addCmdLongDesc = `Adds todos.
 
@@ -20,11 +21,18 @@ func init() {
   This can be done by by putting 'due:<date>' at the end, where <date> is in (tod|today|tom|tomorrow|mon|tue|wed|thu|fri|sat|sun|thisweek|nextweek).
 
   Dates can also be explicit, using 3 characters for the month.  They can be written in 2 different formats:
-
     ultralist a buy flowers for mom due:may12
-    ultralist a get halloween candy due:31oct
+    ultralist get halloween candy due:31oct
 
-  See the full docs at https://ultralist.io/docs/cli/managing_tasks/#adding-todos`
+  See the full docs at https://ultralist.io/docs/cli/managing_tasks/#adding-todos
+
+  Todos can also recur.  Set the 'recur' directive to control recurrence:
+
+    ultralist a Daily standup recur:weekdays
+    ultralist a 1o1 meeting with jim recur:weekly
+
+  For full documentation on recurrence, see:
+  https://ultralist.io/docs/cli/recurrence`
 	)
 
 	var addCmd = &cobra.Command{

--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -26,7 +26,12 @@ func init() {
     ultralist archive gc
     ultralist ar gc
 
-  For the full docs, see https://ultralist.io/docs/cli/managing_tasks/#archivingunarchiving-todos`
+  ultralist archive gc
+  ultralist ar gc
+	  Run garbage collection. Delete all archived todos and reclaim ids
+
+  See the full docs here:
+  https://ultralist.io/docs/cli/managing_tasks`
 	)
 
 	var archiveCmd = &cobra.Command{

--- a/ultralist/app.go
+++ b/ultralist/app.go
@@ -161,7 +161,7 @@ func (a *App) EditTodo(todoID int, input string) {
 		return
 	}
 
-	if err = EditTodo(todo, filter); err != nil {
+	if err = EditTodo(todo, a.TodoList, filter); err != nil {
 		fmt.Println(err.Error())
 		return
 	}

--- a/ultralist/backend.go
+++ b/ultralist/backend.go
@@ -52,6 +52,7 @@ func (b *Backend) PerformRequest(method string, path string, data []byte) []byte
 	req.Header.Set("Authorization", authHeader)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("x-Ultralist-CLI-Version", VERSION)
 
 	client := &http.Client{}
 

--- a/ultralist/create_todo.go
+++ b/ultralist/create_todo.go
@@ -11,6 +11,8 @@ func CreateTodo(filter *Filter) (*Todo, error) {
 		Contexts:   filter.Contexts,
 		Due:        filter.Due,
 		Status:     filter.LastStatus(),
+		Recur:      filter.Recur,
+		RecurUntil: filter.RecurUntil,
 	}
 	if todoItem.Completed {
 		todoItem.Complete()

--- a/ultralist/date_parser.go
+++ b/ultralist/date_parser.go
@@ -37,46 +37,46 @@ func (dp *DateParser) ParseDate(dateString string, pivotDay time.Time) (date tim
 		return dp.sunday(pivotDay), nil
 	case "lastweek":
 		n := bod(pivotDay)
-		return getNearestMonday(n).AddDate(0, 0, -7), nil
+		return dp.getNearestMonday(n).AddDate(0, 0, -7), nil
 	case "nextweek":
 		n := bod(pivotDay)
-		return getNearestMonday(n).AddDate(0, 0, 7), nil
+		return dp.getNearestMonday(n).AddDate(0, 0, 7), nil
 	}
 	return dp.parseSpecificDate(dateString, pivotDay)
 }
 
 func (dp *DateParser) monday(day time.Time) time.Time {
-	mon := getNearestMonday(day)
+	mon := dp.getNearestMonday(day)
 	return dp.thisOrNextWeek(mon, day)
 }
 
 func (dp *DateParser) tuesday(day time.Time) time.Time {
-	tue := getNearestMonday(day).AddDate(0, 0, 1)
+	tue := dp.getNearestMonday(day).AddDate(0, 0, 1)
 	return dp.thisOrNextWeek(tue, day)
 }
 
 func (dp *DateParser) wednesday(day time.Time) time.Time {
-	wed := getNearestMonday(day).AddDate(0, 0, 2)
+	wed := dp.getNearestMonday(day).AddDate(0, 0, 2)
 	return dp.thisOrNextWeek(wed, day)
 }
 
 func (dp *DateParser) thursday(day time.Time) time.Time {
-	thu := getNearestMonday(day).AddDate(0, 0, 3)
+	thu := dp.getNearestMonday(day).AddDate(0, 0, 3)
 	return dp.thisOrNextWeek(thu, day)
 }
 
 func (dp *DateParser) friday(day time.Time) time.Time {
-	fri := getNearestMonday(day).AddDate(0, 0, 4)
+	fri := dp.getNearestMonday(day).AddDate(0, 0, 4)
 	return dp.thisOrNextWeek(fri, day)
 }
 
 func (dp *DateParser) saturday(day time.Time) time.Time {
-	sat := getNearestMonday(day).AddDate(0, 0, 5)
+	sat := dp.getNearestMonday(day).AddDate(0, 0, 5)
 	return dp.thisOrNextWeek(sat, day)
 }
 
 func (dp *DateParser) sunday(day time.Time) time.Time {
-	sun := getNearestMonday(day).AddDate(0, 0, 6)
+	sun := dp.getNearestMonday(day).AddDate(0, 0, 6)
 	return dp.thisOrNextWeek(sun, day)
 }
 
@@ -108,4 +108,14 @@ func (dp *DateParser) parseSpecificDate(date string, pivot time.Time) (time.Time
 	errString := fmt.Sprintf("Could not parse the date you gave me: '%s'", date)
 
 	return time.Time{}, errors.New(errString)
+}
+
+func (dp *DateParser) getNearestMonday(t time.Time) time.Time {
+	for {
+		if t.Weekday() != time.Monday {
+			t = t.AddDate(0, 0, -1)
+		} else {
+			return t
+		}
+	}
 }

--- a/ultralist/edit_todo.go
+++ b/ultralist/edit_todo.go
@@ -1,14 +1,14 @@
 package ultralist
 
 // EditTodo edits a todo based upon a filter
-func EditTodo(todo *Todo, filter *Filter) error {
+func EditTodo(todo *Todo, todoList *TodoList, filter *Filter) error {
 	if filter.HasDue {
 		todo.Due = filter.Due
 	}
 
 	if filter.HasCompleted {
 		if filter.Completed {
-			todo.Complete()
+			todoList.Complete(todo.ID)
 		} else {
 			todo.Uncomplete()
 		}
@@ -36,6 +36,11 @@ func EditTodo(todo *Todo, filter *Filter) error {
 
 	if len(filter.Contexts) > 0 {
 		todo.Contexts = filter.Contexts
+	}
+
+	if filter.HasRecur {
+		todo.Recur = filter.Recur
+		todo.RecurUntil = filter.RecurUntil
 	}
 
 	return nil

--- a/ultralist/edit_todo_test.go
+++ b/ultralist/edit_todo_test.go
@@ -12,10 +12,12 @@ func TestEditTodoProjects(t *testing.T) {
 
 	filter, _ := parser.Parse("+p1")
 	todo, _ := CreateTodo(filter)
+	todoList := &TodoList{}
+	todoList.Data = []*Todo{todo}
 
 	editFilter, _ := parser.Parse("+p2")
 
-	EditTodo(todo, editFilter)
+	EditTodo(todo, todoList, editFilter)
 
 	assert.Equal("+p2", todo.Subject)
 	assert.Equal([]string{"p2"}, todo.Projects)
@@ -27,10 +29,12 @@ func TestEditTodoProjectsOtherSyntax(t *testing.T) {
 
 	filter, _ := parser.Parse("+p1")
 	todo, _ := CreateTodo(filter)
+	todoList := &TodoList{}
+	todoList.Data = []*Todo{todo}
 
 	editFilter, _ := parser.Parse("project:p2")
 
-	EditTodo(todo, editFilter)
+	EditTodo(todo, todoList, editFilter)
 
 	assert.Equal("+p1", todo.Subject)
 	assert.Equal([]string{"p2"}, todo.Projects)

--- a/ultralist/filter.go
+++ b/ultralist/filter.go
@@ -33,6 +33,10 @@ type Filter struct {
 	HasStatus        bool
 	HasProjectFilter bool
 	HasContextFilter bool
+
+	HasRecur   bool
+	Recur      string
+	RecurUntil string
 }
 
 // LastStatus returns the last status from the filter

--- a/ultralist/input_parser.go
+++ b/ultralist/input_parser.go
@@ -171,13 +171,21 @@ func (p *InputParser) Parse(input string) (*Filter, error) {
 		if r.MatchString(word) {
 			filter.HasRecur = true
 			filter.Recur = r.FindString(word)[6:]
+
 			filter.Contexts, filter.ExcludeContexts = p.parseString(r.FindString(word)[8:])
 			match = true
 
-			r, _ = regexp.Compile(`until:.*$`)
-			if r.MatchString(word) {
-				filter.RecurUntil = r.FindString(word)[6:]
+		}
+
+		r, _ = regexp.Compile(`until:.*$`)
+		if r.MatchString(word) {
+			date, err := dateParser.ParseDate(r.FindString(word)[6:], time.Now())
+			if err != nil {
+				return filter, err
 			}
+			match = true
+
+			filter.RecurUntil = date.Format(DATE_FORMAT)
 		}
 
 		if !match {

--- a/ultralist/input_parser.go
+++ b/ultralist/input_parser.go
@@ -48,6 +48,7 @@ func (p *InputParser) Parse(input string) (*Filter, error) {
 		HasDueBefore:     false,
 		HasDue:           false,
 		HasDueAfter:      false,
+		HasRecur:         false,
 	}
 
 	dateParser := &DateParser{}
@@ -164,6 +165,19 @@ func (p *InputParser) Parse(input string) (*Filter, error) {
 			filter.HasContextFilter = true
 			filter.Contexts, filter.ExcludeContexts = p.parseString(r.FindString(word)[8:])
 			match = true
+		}
+
+		r, _ = regexp.Compile(`recur:.*$`)
+		if r.MatchString(word) {
+			filter.HasRecur = true
+			filter.Recur = r.FindString(word)[6:]
+			filter.Contexts, filter.ExcludeContexts = p.parseString(r.FindString(word)[8:])
+			match = true
+
+			r, _ = regexp.Compile(`until:.*$`)
+			if r.MatchString(word) {
+				filter.RecurUntil = r.FindString(word)[6:]
+			}
 		}
 
 		if !match {

--- a/ultralist/input_parser.go
+++ b/ultralist/input_parser.go
@@ -1,6 +1,7 @@
 package ultralist
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 	"time"
@@ -169,12 +170,19 @@ func (p *InputParser) Parse(input string) (*Filter, error) {
 
 		r, _ = regexp.Compile(`recur:.*$`)
 		if r.MatchString(word) {
+			match = true
+
 			filter.HasRecur = true
 			filter.Recur = r.FindString(word)[6:]
 
-			filter.Contexts, filter.ExcludeContexts = p.parseString(r.FindString(word)[8:])
-			match = true
+			if filter.Recur == "none" {
+				filter.Recur = ""
+			}
 
+			r := &Recurrence{}
+			if !r.ValidRecurrence(filter.Recur) {
+				return filter, fmt.Errorf("I could not understand the recurrence you gave me: '%s'", filter.Recur)
+			}
 		}
 
 		r, _ = regexp.Compile(`until:.*$`)

--- a/ultralist/input_parser_test.go
+++ b/ultralist/input_parser_test.go
@@ -113,3 +113,27 @@ func TestNoSubject(t *testing.T) {
 	assert.Equal("", filter.Subject)
 	assert.Equal(true, filter.IsPriority)
 }
+
+func TestInvalidRecurrence(t *testing.T) {
+	assert := assert.New(t)
+	parser := &InputParser{}
+
+	_, err := parser.Parse("recur:blah")
+
+	if err == nil {
+		fmt.Println("expected an error")
+		t.Fail()
+	}
+
+	assert.Equal(err.Error(), "I could not understand the recurrence you gave me: 'blah'")
+}
+
+func TestNoneRecurrence(t *testing.T) {
+	assert := assert.New(t)
+	parser := &InputParser{}
+
+	filter, _ := parser.Parse("recur:none")
+
+	assert.Equal(true, filter.HasRecur)
+	assert.Equal("", filter.Recur)
+}

--- a/ultralist/recurrence.go
+++ b/ultralist/recurrence.go
@@ -1,7 +1,6 @@
 package ultralist
 
 import (
-	"fmt"
 	"time"
 )
 
@@ -49,22 +48,12 @@ func (r *Recurrence) nextRecurrence(dueDate time.Time, completedDate time.Time, 
 		}
 		return completedDate.AddDate(0, 0, 1)
 	case "weekdays":
-		// m, t, w, thu, fri
-		// schedule it for tomorrow unless it's currently friday or saturday, in which case schedule it for next monday
 		return r.findNextWeekDay(dueDate, completedDate)
 	case "monthly":
-		// add one month to the due date
-		// schedule the next on the next month day
 		return r.findNextMonth(dueDate, completedDate)
 	case "weekly":
-		// add one week to the due date
-		// schedule it for the next weekday that's the same day as the due date.
-		// if the due date is in the past, schedule it for the next week day closest to today
-		// if the due date is in the future, schedule it for the weekday after the due date
-
 		return r.findNextWeek(dueDate, completedDate)
 	}
-	fmt.Println("returning base case")
 	return dueDate
 }
 

--- a/ultralist/recurrence.go
+++ b/ultralist/recurrence.go
@@ -1,0 +1,110 @@
+package ultralist
+
+import (
+	"time"
+)
+
+type Recurrence struct{}
+
+// HasNextRecurringTodo
+func (r *Recurrence) HasNextRecurringTodo(todo *Todo) bool {
+	recurUntil, _ := time.Parse(DATE_FORMAT, todo.RecurUntil)
+
+	return todo.Recur != "" &&
+		time.Now().Before(recurUntil) &&
+		!todo.Completed
+}
+
+// NextRecurringTodo generates the next recurring todo from the one passed in.
+func (r *Recurrence) NextRecurringTodo(todo *Todo, completedTime time.Time) *Todo {
+
+	dueDate, _ := time.Parse(DATE_FORMAT, todo.Due)
+	var nextDueDate time.Time
+
+	switch todo.Recur {
+	case "daily":
+		if completedTime.Before(dueDate) {
+			nextDueDate = dueDate.AddDate(0, 0, 1)
+		} else {
+			nextDueDate = completedTime.AddDate(0, 0, 1)
+		}
+	case "weekdays":
+		// m, t, w, thu, fri
+		// schedule it for tomorrow unless it's currently friday or saturday, in which case schedule it for next monday
+		nextDueDate = r.findNextWeekDay(dueDate, completedTime)
+	case "monthly":
+		// add one month to the due date
+		// schedule the next on the next month day
+		nextDueDate = r.findNextMonth(dueDate, completedTime)
+	case "weekly":
+		// add one week to the due date
+		// schedule it for the next weekday that's the same day as the due date.
+		// if the due date is in the past, schedule it for the next week day closest to today
+		// if the due date is in the future, schedule it for the weekday after the due date
+
+		nextDueDate = r.findNextWeek(dueDate, completedTime)
+	}
+
+	return &Todo{
+		UUID:       newUUID(),
+		Completed:  false,
+		Archived:   false,
+		Subject:    todo.Subject,
+		Projects:   todo.Projects,
+		Contexts:   todo.Contexts,
+		Status:     todo.Status,
+		IsPriority: todo.IsPriority,
+		Notes:      todo.Notes,
+		Recur:      todo.Recur,
+		Due:        nextDueDate.Format(DATE_FORMAT),
+		RecurUntil: todo.RecurUntil,
+	}
+}
+
+func (r *Recurrence) findNextWeekDay(dueDate time.Time, completedDate time.Time) time.Time {
+	dueDate = dueDate.AddDate(0, 0, 1)
+
+	for {
+		if !r.isWeekday(dueDate) || dueDate.Before(completedDate) {
+			dueDate = dueDate.AddDate(0, 0, 1)
+		} else {
+			return dueDate
+		}
+	}
+}
+
+func (r *Recurrence) isWeekday(t time.Time) bool {
+	switch t.Weekday() {
+	case
+		time.Monday,
+		time.Tuesday,
+		time.Wednesday,
+		time.Thursday,
+		time.Friday:
+		return true
+	}
+	return false
+}
+
+func (r *Recurrence) findNextWeek(dueDate time.Time, completedDate time.Time) time.Time {
+	weekday := dueDate.Weekday()
+	dueDate = dueDate.AddDate(0, 0, 1)
+	for {
+		if dueDate.Weekday() != weekday || dueDate.Before(completedDate) {
+			dueDate = dueDate.AddDate(0, 0, 1)
+		} else {
+			return dueDate
+		}
+	}
+}
+
+func (r *Recurrence) findNextMonth(dueDate time.Time, completedDate time.Time) time.Time {
+	dueDate = dueDate.AddDate(0, 1, 0)
+	for {
+		if dueDate.Before(completedDate) {
+			dueDate = dueDate.AddDate(0, 1, 0)
+		} else {
+			return dueDate
+		}
+	}
+}

--- a/ultralist/recurrence.go
+++ b/ultralist/recurrence.go
@@ -49,10 +49,12 @@ func (r *Recurrence) nextRecurrence(dueDate time.Time, completedDate time.Time, 
 		return completedDate.AddDate(0, 0, 1)
 	case "weekdays":
 		return r.findNextWeekDay(dueDate, completedDate)
-	case "monthly":
-		return r.findNextMonth(dueDate, completedDate)
 	case "weekly":
 		return r.findNextWeek(dueDate, completedDate)
+	case "monthly":
+		return r.findNextMonth(dueDate, completedDate)
+	case "yearly":
+		return r.findNextYear(dueDate, completedDate)
 	}
 	return dueDate
 }
@@ -99,6 +101,17 @@ func (r *Recurrence) findNextMonth(dueDate time.Time, completedDate time.Time) t
 	for {
 		if dueDate.Before(completedDate) {
 			dueDate = dueDate.AddDate(0, 1, 0)
+		} else {
+			return dueDate
+		}
+	}
+}
+
+func (r *Recurrence) findNextYear(dueDate time.Time, completedDate time.Time) time.Time {
+	dueDate = dueDate.AddDate(1, 0, 0)
+	for {
+		if dueDate.Before(completedDate) {
+			dueDate = dueDate.AddDate(1, 0, 0)
 		} else {
 			return dueDate
 		}

--- a/ultralist/recurrence.go
+++ b/ultralist/recurrence.go
@@ -4,8 +4,30 @@ import (
 	"time"
 )
 
+const (
+	Daily    = "daily"
+	Weekdays = "weekdays"
+	Weekly   = "weekly"
+	Monthly  = "monthly"
+	Yearly   = "yearly"
+)
+
 // Recurrence struct contains the logic for dealing with recurring todos.
 type Recurrence struct{}
+
+// ValidRecurrence takes an input string and determines if the value is a valid ultralist recurrence.
+func (r *Recurrence) ValidRecurrence(input string) bool {
+	switch input {
+	case
+		Daily,
+		Weekdays,
+		Weekly,
+		Monthly,
+		Yearly:
+		return true
+	}
+	return false
+}
 
 // HasNextRecurringTodo determines if a todo has a next recurrence.
 func (r *Recurrence) HasNextRecurringTodo(todo *Todo) bool {
@@ -42,18 +64,18 @@ func (r *Recurrence) NextRecurringTodo(todo *Todo, completedDate time.Time) *Tod
 
 func (r *Recurrence) nextRecurrence(dueDate time.Time, completedDate time.Time, recurrence string) time.Time {
 	switch recurrence {
-	case "daily":
+	case Daily:
 		if completedDate.Before(dueDate) {
 			return dueDate.AddDate(0, 0, 1)
 		}
 		return completedDate.AddDate(0, 0, 1)
-	case "weekdays":
+	case Weekdays:
 		return r.findNextWeekDay(dueDate, completedDate)
-	case "weekly":
+	case Weekly:
 		return r.findNextWeek(dueDate, completedDate)
-	case "monthly":
+	case Monthly:
 		return r.findNextMonth(dueDate, completedDate)
-	case "yearly":
+	case Yearly:
 		return r.findNextYear(dueDate, completedDate)
 	}
 	return dueDate

--- a/ultralist/recurrence.go
+++ b/ultralist/recurrence.go
@@ -86,7 +86,7 @@ func (r *Recurrence) findNextWeekDay(dueDate time.Time, completedDate time.Time)
 	dueDate = dueDate.AddDate(0, 0, 1)
 
 	for {
-		if !r.isWeekday(dueDate) || dueDate.Before(completedDate) {
+		if !r.isWeekday(dueDate) || dueDate.Before(completedDate.AddDate(0, 0, 1)) {
 			dueDate = dueDate.AddDate(0, 0, 1)
 		} else {
 			return dueDate
@@ -111,7 +111,7 @@ func (r *Recurrence) findNextWeek(dueDate time.Time, completedDate time.Time) ti
 	weekday := dueDate.Weekday()
 	dueDate = dueDate.AddDate(0, 0, 1)
 	for {
-		if dueDate.Weekday() != weekday || dueDate.Before(completedDate) {
+		if dueDate.Weekday() != weekday || dueDate.Before(completedDate.AddDate(0, 0, 1)) {
 			dueDate = dueDate.AddDate(0, 0, 1)
 		} else {
 			return dueDate
@@ -122,7 +122,7 @@ func (r *Recurrence) findNextWeek(dueDate time.Time, completedDate time.Time) ti
 func (r *Recurrence) findNextMonth(dueDate time.Time, completedDate time.Time) time.Time {
 	dueDate = dueDate.AddDate(0, 1, 0)
 	for {
-		if dueDate.Before(completedDate) {
+		if dueDate.Before(completedDate.AddDate(0, 0, 1)) {
 			dueDate = dueDate.AddDate(0, 1, 0)
 		} else {
 			return dueDate
@@ -133,7 +133,7 @@ func (r *Recurrence) findNextMonth(dueDate time.Time, completedDate time.Time) t
 func (r *Recurrence) findNextYear(dueDate time.Time, completedDate time.Time) time.Time {
 	dueDate = dueDate.AddDate(1, 0, 0)
 	for {
-		if dueDate.Before(completedDate) {
+		if dueDate.Before(completedDate.AddDate(0, 0, 1)) {
 			dueDate = dueDate.AddDate(1, 0, 0)
 		} else {
 			return dueDate

--- a/ultralist/recurrence.go
+++ b/ultralist/recurrence.go
@@ -47,18 +47,19 @@ func (r *Recurrence) NextRecurringTodo(todo *Todo, completedDate time.Time) *Tod
 	nextDueDate := r.nextRecurrence(dueDate, completedDate, todo.Recur)
 
 	return &Todo{
-		UUID:       newUUID(),
-		Completed:  false,
-		Archived:   false,
-		Subject:    todo.Subject,
-		Projects:   todo.Projects,
-		Contexts:   todo.Contexts,
-		Status:     todo.Status,
-		IsPriority: todo.IsPriority,
-		Notes:      todo.Notes,
-		Recur:      todo.Recur,
-		Due:        nextDueDate.Format(DATE_FORMAT),
-		RecurUntil: todo.RecurUntil,
+		UUID:              newUUID(),
+		Completed:         false,
+		Archived:          false,
+		Subject:           todo.Subject,
+		Projects:          todo.Projects,
+		Contexts:          todo.Contexts,
+		Status:            todo.Status,
+		IsPriority:        todo.IsPriority,
+		Notes:             todo.Notes,
+		Recur:             todo.Recur,
+		Due:               nextDueDate.Format(DATE_FORMAT),
+		RecurUntil:        todo.RecurUntil,
+		PrevRecurTodoUUID: todo.UUID,
 	}
 }
 

--- a/ultralist/recurrence_test.go
+++ b/ultralist/recurrence_test.go
@@ -1,0 +1,166 @@
+package ultralist
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWeeklyCompleteWeekBefore(t *testing.T) {
+	assert := assert.New(t)
+
+	r := &Recurrence{}
+	pivot, _ := time.Parse(DATE_FORMAT, "2020-10-17")
+	// Wed, Oct 28
+	todo := &Todo{Recur: "weekly", Due: "2020-10-28"}
+
+	nextTodo := r.NextRecurringTodo(todo, pivot)
+
+	assert.Equal("2020-11-04", nextTodo.Due)
+}
+
+func TestWeeklyCompleteDayBefore(t *testing.T) {
+	assert := assert.New(t)
+
+	r := &Recurrence{}
+	pivot, _ := time.Parse(DATE_FORMAT, "2020-10-27")
+	// Wed, Oct 28
+	todo := &Todo{Recur: "weekly", Due: "2020-10-28"}
+
+	nextTodo := r.NextRecurringTodo(todo, pivot)
+
+	assert.Equal("2020-11-04", nextTodo.Due)
+}
+
+func TestWeeklyCompleteDayOf(t *testing.T) {
+	assert := assert.New(t)
+
+	r := &Recurrence{}
+	pivot, _ := time.Parse(DATE_FORMAT, "2020-10-28")
+	todo := &Todo{Recur: "weekly", Due: "2020-10-28"}
+
+	nextTodo := r.NextRecurringTodo(todo, pivot)
+
+	assert.Equal("2020-11-04", nextTodo.Due)
+}
+
+func TestWeeklyCompleteDayAfter(t *testing.T) {
+	assert := assert.New(t)
+
+	r := &Recurrence{}
+	pivot, _ := time.Parse(DATE_FORMAT, "2020-10-29")
+	todo := &Todo{Recur: "weekly", Due: "2020-10-28"}
+
+	nextTodo := r.NextRecurringTodo(todo, pivot)
+
+	assert.Equal("2020-11-04", nextTodo.Due)
+}
+
+func TestWeeklyCompleteWeekAfter(t *testing.T) {
+	assert := assert.New(t)
+
+	r := &Recurrence{}
+	pivot, _ := time.Parse(DATE_FORMAT, "2020-11-10")
+	todo := &Todo{Recur: "weekly", Due: "2020-10-28"}
+
+	nextTodo := r.NextRecurringTodo(todo, pivot)
+
+	assert.Equal("2020-11-11", nextTodo.Due)
+}
+
+func TestMonthlyCompletedBefore(t *testing.T) {
+	assert := assert.New(t)
+
+	r := &Recurrence{}
+	pivot, _ := time.Parse(DATE_FORMAT, "2020-08-28")
+	todo := &Todo{Recur: "monthly", Due: "2020-10-28"}
+
+	nextTodo := r.NextRecurringTodo(todo, pivot)
+
+	assert.Equal("2020-11-28", nextTodo.Due)
+}
+
+func TestMonthlyCompletedDayOf(t *testing.T) {
+	assert := assert.New(t)
+
+	r := &Recurrence{}
+	pivot, _ := time.Parse(DATE_FORMAT, "2020-10-28")
+	todo := &Todo{Recur: "monthly", Due: "2020-10-28"}
+
+	nextTodo := r.NextRecurringTodo(todo, pivot)
+
+	assert.Equal("2020-11-28", nextTodo.Due)
+}
+
+func TestMonthlyCompletedAfter(t *testing.T) {
+	assert := assert.New(t)
+
+	r := &Recurrence{}
+	pivot, _ := time.Parse(DATE_FORMAT, "2020-11-29")
+	todo := &Todo{Recur: "monthly", Due: "2020-10-28"}
+
+	nextTodo := r.NextRecurringTodo(todo, pivot)
+
+	assert.Equal("2020-12-28", nextTodo.Due)
+}
+
+func TestWeekDaysOnMonday(t *testing.T) {
+	assert := assert.New(t)
+
+	r := &Recurrence{}
+	pivot, _ := time.Parse(DATE_FORMAT, "2020-11-02")
+	todo := &Todo{Recur: "weekdays", Due: "2020-11-02"}
+
+	nextTodo := r.NextRecurringTodo(todo, pivot)
+
+	assert.Equal("2020-11-03", nextTodo.Due)
+}
+
+func TestWeekDaysOnFriday(t *testing.T) {
+	assert := assert.New(t)
+
+	r := &Recurrence{}
+	pivot, _ := time.Parse(DATE_FORMAT, "2020-11-06")
+	todo := &Todo{Recur: "weekdays", Due: "2020-11-06"}
+
+	nextTodo := r.NextRecurringTodo(todo, pivot)
+
+	assert.Equal("2020-11-09", nextTodo.Due)
+}
+
+func TestDailySameDay(t *testing.T) {
+	assert := assert.New(t)
+
+	r := &Recurrence{}
+	pivot, _ := time.Parse(DATE_FORMAT, "2020-11-06")
+	todo := &Todo{Recur: "daily", Due: "2020-11-06"}
+
+	nextTodo := r.NextRecurringTodo(todo, pivot)
+
+	assert.Equal("2020-11-07", nextTodo.Due)
+}
+
+func TestDailyOverdue(t *testing.T) {
+	assert := assert.New(t)
+
+	r := &Recurrence{}
+	pivot, _ := time.Parse(DATE_FORMAT, "2020-11-09")
+	todo := &Todo{Recur: "daily", Due: "2020-11-06"}
+
+	nextTodo := r.NextRecurringTodo(todo, pivot)
+
+	assert.Equal("2020-11-10", nextTodo.Due)
+}
+
+func TestDailyEarly(t *testing.T) {
+	assert := assert.New(t)
+
+	r := &Recurrence{}
+	pivot, _ := time.Parse(DATE_FORMAT, "2020-11-04")
+	todo := &Todo{Recur: "daily", Due: "2020-11-06"}
+
+	nextTodo := r.NextRecurringTodo(todo, pivot)
+
+	assert.Equal("2020-11-07", nextTodo.Due)
+}

--- a/ultralist/recurrence_test.go
+++ b/ultralist/recurrence_test.go
@@ -7,6 +7,43 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestHasNextRecurringTodoNoRecur(t *testing.T) {
+	assert := assert.New(t)
+
+	r := &Recurrence{}
+	todo := &Todo{Recur: "", RecurUntil: "", Due: "2020-10-28"}
+
+	assert.Equal(false, r.HasNextRecurringTodo(todo))
+}
+
+func TestHasNextRecurringTodoWithUntilNotExpired(t *testing.T) {
+	assert := assert.New(t)
+
+	r := &Recurrence{}
+	tomorrow := time.Now().AddDate(0, 0, 1).Format(DATE_FORMAT)
+	todo := &Todo{Recur: "daily", RecurUntil: tomorrow, Due: "2020-10-28"}
+
+	assert.Equal(true, r.HasNextRecurringTodo(todo))
+}
+
+func TestHasNextRecurringTodoWithExpiredUntil(t *testing.T) {
+	assert := assert.New(t)
+
+	r := &Recurrence{}
+	todo := &Todo{Recur: "weekly", RecurUntil: "2020-10-28", Due: "2020-10-28"}
+
+	assert.Equal(false, r.HasNextRecurringTodo(todo))
+}
+
+func TestHasNextRecurringTodoWithoutUntil(t *testing.T) {
+	assert := assert.New(t)
+
+	r := &Recurrence{}
+	todo := &Todo{Recur: "weekly", RecurUntil: "", Due: "2020-10-28"}
+
+	assert.Equal(true, r.HasNextRecurringTodo(todo))
+}
+
 func TestWeeklyCompleteWeekBefore(t *testing.T) {
 	assert := assert.New(t)
 

--- a/ultralist/recurrence_test.go
+++ b/ultralist/recurrence_test.go
@@ -190,6 +190,18 @@ func TestDailyOverdue(t *testing.T) {
 	assert.Equal("2020-11-10", nextTodo.Due)
 }
 
+func TestDailyDueInFuture(t *testing.T) {
+	assert := assert.New(t)
+
+	r := &Recurrence{}
+	pivot, _ := time.Parse(DATE_FORMAT, "2020-11-09")
+	todo := &Todo{Recur: "daily", Due: "2020-11-12"}
+
+	nextTodo := r.NextRecurringTodo(todo, pivot)
+
+	assert.Equal("2020-11-13", nextTodo.Due)
+}
+
 func TestDailyEarly(t *testing.T) {
 	assert := assert.New(t)
 
@@ -200,4 +212,16 @@ func TestDailyEarly(t *testing.T) {
 	nextTodo := r.NextRecurringTodo(todo, pivot)
 
 	assert.Equal("2020-11-07", nextTodo.Due)
+}
+
+func TestYearly(t *testing.T) {
+	assert := assert.New(t)
+
+	r := &Recurrence{}
+	pivot, _ := time.Parse(DATE_FORMAT, "2020-11-04")
+	todo := &Todo{Recur: "yearly", Due: "2020-11-06"}
+
+	nextTodo := r.NextRecurringTodo(todo, pivot)
+
+	assert.Equal("2021-11-06", nextTodo.Due)
 }

--- a/ultralist/recurrence_test.go
+++ b/ultralist/recurrence_test.go
@@ -62,7 +62,6 @@ func TestWeeklyCompleteDayBefore(t *testing.T) {
 
 	r := &Recurrence{}
 	pivot, _ := time.Parse(DATE_FORMAT, "2020-10-27")
-	// Wed, Oct 28
 	todo := &Todo{Recur: "weekly", Due: "2020-10-28"}
 
 	nextTodo := r.NextRecurringTodo(todo, pivot)
@@ -86,12 +85,12 @@ func TestWeeklyCompleteDayAfter(t *testing.T) {
 	assert := assert.New(t)
 
 	r := &Recurrence{}
-	pivot, _ := time.Parse(DATE_FORMAT, "2020-10-29")
-	todo := &Todo{Recur: "weekly", Due: "2020-10-28"}
+	pivot, _ := time.Parse(DATE_FORMAT, "2020-11-10")
+	todo := &Todo{Recur: "weekly", Due: "2020-11-02"}
 
 	nextTodo := r.NextRecurringTodo(todo, pivot)
 
-	assert.Equal("2020-11-04", nextTodo.Due)
+	assert.Equal("2020-11-16", nextTodo.Due)
 }
 
 func TestWeeklyCompleteWeekAfter(t *testing.T) {
@@ -164,6 +163,18 @@ func TestWeekDaysOnFriday(t *testing.T) {
 	nextTodo := r.NextRecurringTodo(todo, pivot)
 
 	assert.Equal("2020-11-09", nextTodo.Due)
+}
+
+func TestWeekDaysInPast(t *testing.T) {
+	assert := assert.New(t)
+
+	r := &Recurrence{}
+	pivot, _ := time.Parse(DATE_FORMAT, "2020-11-10")
+	todo := &Todo{Recur: "weekdays", Due: "2020-11-05"}
+
+	nextTodo := r.NextRecurringTodo(todo, pivot)
+
+	assert.Equal("2020-11-11", nextTodo.Due)
 }
 
 func TestDailySameDay(t *testing.T) {

--- a/ultralist/todo_filter.go
+++ b/ultralist/todo_filter.go
@@ -76,6 +76,12 @@ func (f *TodoFilter) ApplyFilter() []*Todo {
 			}
 		}
 
+		if f.Filter.HasRecur {
+			if todo.Recur != f.Filter.Recur {
+				continue
+			}
+		}
+
 		// finally, if we're still here, append the todo to the filtered list
 		filtered = append(filtered, todo)
 	}

--- a/ultralist/todo_item.go
+++ b/ultralist/todo_item.go
@@ -22,6 +22,8 @@ type Todo struct {
 	Archived      bool     `json:"archived"`
 	IsPriority    bool     `json:"is_priority"`
 	Notes         []string `json:"notes"`
+	Recur         string   `json:"recur"`
+	RecurUntil    string   `json:"recur_until"`
 }
 
 // NewTodo is creating a new todo item.

--- a/ultralist/todo_item.go
+++ b/ultralist/todo_item.go
@@ -10,20 +10,21 @@ const iso8601TimestampFormat = "2006-01-02T15:04:05Z07:00"
 
 // Todo is the struct for a todo item.
 type Todo struct {
-	ID            int      `json:"id"`
-	UUID          string   `json:"uuid"`
-	Subject       string   `json:"subject"`
-	Projects      []string `json:"projects"`
-	Contexts      []string `json:"contexts"`
-	Due           string   `json:"due"`
-	Completed     bool     `json:"completed"`
-	CompletedDate string   `json:"completed_date"`
-	Status        string   `json:"status"`
-	Archived      bool     `json:"archived"`
-	IsPriority    bool     `json:"is_priority"`
-	Notes         []string `json:"notes"`
-	Recur         string   `json:"recur"`
-	RecurUntil    string   `json:"recur_until"`
+	ID                int      `json:"id"`
+	UUID              string   `json:"uuid"`
+	Subject           string   `json:"subject"`
+	Projects          []string `json:"projects"`
+	Contexts          []string `json:"contexts"`
+	Due               string   `json:"due"`
+	Completed         bool     `json:"completed"`
+	CompletedDate     string   `json:"completed_date"`
+	Status            string   `json:"status"`
+	Archived          bool     `json:"archived"`
+	IsPriority        bool     `json:"is_priority"`
+	Notes             []string `json:"notes"`
+	Recur             string   `json:"recur"`
+	RecurUntil        string   `json:"recur_until"`
+	PrevRecurTodoUUID string   `json:"prev_recur_todo_uuid"`
 }
 
 // NewTodo is creating a new todo item.
@@ -107,6 +108,8 @@ func (t Todo) Equals(other *Todo) bool {
 		t.CompletedDate != other.CompletedDate ||
 		t.Archived != other.Archived ||
 		t.IsPriority != other.IsPriority ||
+		t.Recur != other.Recur ||
+		t.RecurUntil != other.RecurUntil ||
 		!reflect.DeepEqual(t.Notes, other.Notes) {
 		return false
 	}

--- a/ultralist/todo_item.go
+++ b/ultralist/todo_item.go
@@ -89,10 +89,7 @@ func (t Todo) CompletedDateToDate() string {
 
 // HasNotes is showing if an todo has notes.
 func (t Todo) HasNotes() bool {
-	if len(t.Notes) > 0 {
-		return true
-	}
-	return false
+	return len(t.Notes) > 0
 }
 
 // Equals compares 2 todos for equality.

--- a/ultralist/todo_list.go
+++ b/ultralist/todo_list.go
@@ -2,6 +2,7 @@ package ultralist
 
 import (
 	"sort"
+	"time"
 )
 
 // TodoList is the struct of a list with several todos.
@@ -48,9 +49,17 @@ func (t *TodoList) Complete(ids ...int) {
 		if todo == nil {
 			continue
 		}
+		prevStatus := todo.Status
 		todo.Complete()
 		t.Delete(id)
 		t.Data = append(t.Data, todo)
+
+		r := &Recurrence{}
+		if r.HasNextRecurringTodo(todo) {
+			next := r.NextRecurringTodo(todo, time.Now())
+			next.Status = prevStatus
+			t.Add(next)
+		}
 	}
 }
 

--- a/ultralist/util.go
+++ b/ultralist/util.go
@@ -65,16 +65,6 @@ func timestamp(t time.Time) time.Time {
 	return time.Date(year, month, day, hour, min, sec, 0, t.Location())
 }
 
-func getNearestMonday(t time.Time) time.Time {
-	for {
-		if t.Weekday() != time.Monday {
-			t = t.AddDate(0, 0, -1)
-		} else {
-			return t
-		}
-	}
-}
-
 func pluralize(count int, singular, plural string) string {
 	if count > 1 {
 		return plural


### PR DESCRIPTION
This PR implements recurrence functionality for ultralist.

Example:
`ultralist add this is a recurring todo recur:weekdays until:2020-12-31`

The next recurring task gets created when the previous recurring task gets completed.

Supported recurrences:

* `daily`
* `weekdays`
* `weekly`
* `monthly`
* `yearly`

There is also an `until` directive that will stop recurrence functionality.