### PR TITLE
fix input for add note regex

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -48,7 +48,7 @@ var addNoteCmd = &cobra.Command{
 	Long:    addNoteCmdLongDesc,
 	Short:   addNoteCmdDesc,
 	Run: func(cmd *cobra.Command, args []string) {
-		ultralist.NewApp().HandleNotes("an " + strings.Join(args, " "))
+		ultralist.NewApp().HandleNotes(strings.Join(args, " "))
 	},
 }
 

--- a/ultralist/app.go
+++ b/ultralist/app.go
@@ -186,14 +186,14 @@ func (a *App) HandleNotes(input string) {
 		return
 	}
 	parser := &NoteParser{}
-
-	if parser.ParseAddNote(todo, input) {
+	regexedInput := "an " + input
+	if parser.ParseAddNote(todo, regexedInput) {
 		fmt.Println("Note added.")
-	} else if parser.ParseDeleteNote(todo, input) {
+	} else if parser.ParseDeleteNote(todo, regexedInput) {
 		fmt.Println("Note deleted.")
-	} else if parser.ParseEditNote(todo, input) {
+	} else if parser.ParseEditNote(todo, regexedInput) {
 		fmt.Println("Note edited.")
-	} else if parser.ParseShowNote(todo, input) {
+	} else if parser.ParseShowNote(todo, regexedInput) {
 		groups := map[string][]*Todo{}
 		groups[""] = append(groups[""], todo)
 		a.Printer.Print(&GroupedTodos{Groups: groups}, true, true)


### PR DESCRIPTION
Add note function doesn't work . How to reproduce ? 
```
 ulist a n 4 test
```
Output
```
Invalid id: 'an'
```
### Reason
Get id function in AddNote expecting an id in index 0 but you added "an" to args so first argument is an instead of id. I removed it and added later for Parser functions 
